### PR TITLE
fix: support tsx files in babel plugin scanning

### DIFF
--- a/src/babel/helpers.ts
+++ b/src/babel/helpers.ts
@@ -30,8 +30,8 @@ function getFilesWithoutExtension(dirPath: string) {
   const files = entries.filter(
     (entry) =>
       entry.isFile() &&
-      /\.[jt]sx$/.exec(entry.name) &&
-      !/index\.[jt]sx$/.exec(entry.name),
+      /\.[jt]sx?$/.exec(entry.name) &&
+      !/index\.[jt]sx?$/.exec(entry.name),
   );
 
   // For each file, get the filename without extension


### PR DESCRIPTION
The scanning takes place on the `dist` folder which has already transformed jsx to js so ensure the `x` is optional.