### PR TITLE
fix: unexpected expection when style array contains undefined

### DIFF
--- a/src/runtime/native/react/rules.ts
+++ b/src/runtime/native/react/rules.ts
@@ -71,6 +71,10 @@ export function updateRules(
     if (target) {
       if (Array.isArray(target)) {
         for (const item of target) {
+          // undefined is allowed in style array
+          if (!item) {
+            continue;
+          }
           if (VAR_SYMBOL in item) {
             inlineVariables.add(item);
           } else if (


### PR DESCRIPTION
Currently, when the style prop is an array and contains undefined, it may throw "right operand of 'in' is not an object"

for example: 
https://github.com/react-navigation/react-navigation/blob/main/packages/elements/src/SafeAreaProviderCompat.tsx#L36

https://github.com/expo/expo/blob/main/packages/expo-router/src/views/Unmatched.tsx#L110