### PR TITLE
fix: box shadow from css variables

### DIFF
--- a/src/__tests__/native/variables.test.tsx
+++ b/src/__tests__/native/variables.test.tsx
@@ -231,6 +231,102 @@ test("ratio values", () => {
   expect(component.props.style).toStrictEqual({ aspectRatio: "16 / 9" });
 });
 
+test("shadow values - single", () => {
+  registerCSS(`
+    :root { --color: #fb2c36; --my-var: 0 20px 25px -5px var(--color); }
+    .test { box-shadow: var(--my-var); }
+  `);
+
+  // Since we can't directly test the hook in isolation with the render approach,
+  // we'll test that a component using the variable gets the correct value
+  render(<View testID={testID} className="test" />);
+  const component = screen.getByTestId(testID);
+
+  expect(component.props.style).toStrictEqual({
+    boxShadow: [
+      {
+        blurRadius: 25,
+        color: "#fb2c36",
+        offsetX: 0,
+        offsetY: 20,
+        spreadDistance: -5,
+      },
+    ],
+  });
+});
+
+test("shadow values - multiple", () => {
+  // registerCSS(`
+  //   :root { --color: #fb2c36; --my-var: 0 20px 25px -5px var(--color); }
+  //   .test { box-shadow: var(--my-var), var(--my-var); }
+  // `);
+
+  registerCSS(`
+    :root {
+      --my-var: 0 20px 0 0 red, 0 30px 0 0 green;
+      --my-var-2: var(--my-var), 0 40px 0 0 purple;
+      --my-var-3: 0 50px 0 0 yellow, 0 60px 0 0 orange;
+      --my-var-4: var(--my-var-3), 0 70px 0 0 gray;
+    }
+    .test {
+      box-shadow: var(--my-var-2), var(--my-var-4);
+    }
+  `);
+
+  // Since we can't directly test the hook in isolation with the render approach,
+  // we'll test that a component using the variable gets the correct value
+  render(<View testID={testID} className="test" />);
+  const component = screen.getByTestId(testID);
+
+  expect(component.props.style).toStrictEqual({
+    boxShadow: [
+      {
+        blurRadius: 0,
+        color: "red",
+        offsetX: 0,
+        offsetY: 20,
+        spreadDistance: 0,
+      },
+
+      {
+        blurRadius: 0,
+        color: "green",
+        offsetX: 0,
+        offsetY: 30,
+        spreadDistance: 0,
+      },
+      {
+        blurRadius: 0,
+        color: "purple",
+        offsetX: 0,
+        offsetY: 40,
+        spreadDistance: 0,
+      },
+      {
+        blurRadius: 0,
+        color: "yellow",
+        offsetX: 0,
+        offsetY: 50,
+        spreadDistance: 0,
+      },
+      {
+        blurRadius: 0,
+        color: "orange",
+        offsetX: 0,
+        offsetY: 60,
+        spreadDistance: 0,
+      },
+      {
+        blurRadius: 0,
+        color: "gray",
+        offsetX: 0,
+        offsetY: 70,
+        spreadDistance: 0,
+      },
+    ],
+  });
+});
+
 test("VariableContextProvider", () => {
   registerCSS(`
     .test { color: var(--my-var); }


### PR DESCRIPTION
Fix to correctly apply all nested boxShadows from multiple css variables. 
This also fixes applying single boxShadow from css variable.