### PR TITLE
Fixing Issue with text classes from TW 5

### DIFF
--- a/src/components/TextInput.tsx
+++ b/src/components/TextInput.tsx
@@ -12,7 +12,7 @@ const mapping: StyledConfiguration<typeof RNTextInput> = {
   className: {
     target: "style",
     nativeStyleMapping: {
-      textAlign: true,
+      textAlign: "textAlign",
     },
   },
 };


### PR DESCRIPTION
When using Variants with text-centre, text-left, or text-right, we have a Bug as it shows [here](https://github.com/nativewind/react-native-css/issues/232)  