### PR TITLE
ci: add release-type input to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,18 @@
 name: Release & Publish to NPM
 
-on: workflow_dispatch
+on:
+  workflow_dispatch:
+    inputs:
+      release-type:
+        description: "Release type"
+        required: true
+        default: "preview"
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+          - preview
 
 permissions:
   contents: write
@@ -31,7 +43,11 @@ jobs:
 
       - name: Run release
         run: |
-          yarn release --ci --preRelease=preview
+          if [ "${{ inputs.release-type }}" = "preview" ]; then
+            yarn release --ci --preRelease=preview
+          else
+            yarn release --ci --increment=${{ inputs.release-type }}
+          fi
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary

- Adds a `release-type` input to the release workflow (`workflow_dispatch`) with options: `patch`, `minor`, `major`, `preview`
- Defaults to `preview` (preserving current behavior)
- For stable releases (`patch`/`minor`/`major`), runs `yarn release --ci --increment=<type>` instead of `--preRelease=preview`

## Context

The workflow previously always published a preview prerelease. This change allows triggering stable patch/minor/major releases from the GitHub Actions UI.

Made with [Cursor](https://cursor.com)