### PR TITLE
fix: resolve native SafeAreaProvider via exports map

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,18 @@
         "types": "./dist/typescript/commonjs/src/components/index.d.ts"
       }
     },
+    "./components/react-native-safe-area-context": {
+      "source": "./src/components/react-native-safe-area-context.native.tsx",
+      "react-native": "./src/components/react-native-safe-area-context.native.tsx",
+      "import": {
+        "types": "./dist/typescript/module/src/components/react-native-safe-area-context.d.ts",
+        "default": "./dist/module/components/react-native-safe-area-context.js"
+      },
+      "require": {
+        "types": "./dist/typescript/commonjs/src/components/react-native-safe-area-context.d.ts",
+        "default": "./dist/commonjs/components/react-native-safe-area-context.js"
+      }
+    },
     "./components/*": {
       "source": "./src/components/*.tsx",
       "react-native": "./src/components/*.tsx",

--- a/src/__tests__/native/env.test.ios.tsx
+++ b/src/__tests__/native/env.test.ios.tsx
@@ -1,18 +1,15 @@
-// import { SafeAreaProvider } from "react-native-css/components/SafeAreaProvider";
 import { render, screen } from "@testing-library/react-native";
+import { SafeAreaProvider } from "react-native-css/components/SafeAreaProvider";
 import { View } from "react-native-css/components/View";
 import { registerCSS, testID } from "react-native-css/jest";
 
-test.skip("safe-area-inset-*", () => {
+test("safe-area-inset-*", () => {
   registerCSS(`.my-class {
     margin-top: env(safe-area-inset-top);
     margin-bottom: env(safe-area-inset-bottom);
     margin-left: env(safe-area-inset-left);
     margin-right: env(safe-area-inset-right);
   }`);
-
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const SafeAreaProvider = View as any;
 
   render(
     <SafeAreaProvider

--- a/src/components/SafeAreaProvider.tsx
+++ b/src/components/SafeAreaProvider.tsx
@@ -1,0 +1,1 @@
+export { SafeAreaProvider } from "react-native-css/components/react-native-safe-area-context";


### PR DESCRIPTION
## Summary

- **Bug**: `env(safe-area-inset-*)` values resolve to 0 on native when applied via `className` (e.g. `mb-safe`, `p-safe`). The `SafeAreaEnv` component that injects CSS variables into the `VariableContext` is never loaded.
- **Root cause**: The `./components/*` wildcard in the `exports` map resolves to `react-native-safe-area-context.tsx` (the web passthrough) instead of `react-native-safe-area-context.native.tsx` (the native wrapper with `SafeAreaEnv`). Metro treats exports-resolved paths as final and does not apply platform-suffix resolution.
- **Fix**: Add an explicit, higher-specificity exports entry for `./components/react-native-safe-area-context` that maps the `react-native` condition directly to `.native.tsx`.

Additionally:
- Add `SafeAreaProvider.tsx` as a convenience re-export, consistent with the component naming pattern used by `View`, `Text`, etc.
- Enable the previously skipped `env(safe-area-inset-*)` test.

Closes https://github.com/nativewind/react-native-css/issues/234

## Test plan

- [x] `env.test.ios.tsx` passes (previously skipped)
- [x] All native tests pass (`npx jest src/__tests__/native/`)
- [x] Verified via Metro bundle that `SafeAreaEnv` and `react-native-css-safe-area-inset-*` variables are present in the iOS bundle
- [x] Verified on iPhone 16 simulator (iOS 18.4) that `mb-safe` produces visible bottom margin