### PR TITLE
fix(types): move @types/debug from devDependencies to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -197,6 +197,7 @@
     "!**/__mocks__"
   ],
   "dependencies": {
+    "@types/debug": "^4.1.12",
     "babel-plugin-react-compiler": "^19.1.0-rc.2",
     "colorjs.io": "0.6.0-alpha.1",
     "comment-json": "^4.2.5",
@@ -218,7 +219,6 @@
     "@testing-library/react-native": "^13.3.3",
     "@tsconfig/react-native": "^3.0.6",
     "@types/babel__core": "^7",
-    "@types/debug": "^4.1.12",
     "@types/jest": "^30.0.0",
     "@types/react": "^19.1.10",
     "@types/react-test-renderer": "^19",


### PR DESCRIPTION
## Summary

`compiler.types.ts` exports the `Debugger` type from `"debug"` in the public `CompilerOptions.logger` type:

```typescript
// src/compiler/compiler.types.ts
import type { Debugger } from "debug";

export interface CompilerOptions {
  logger?: (message: string) => void | Debugger;
}
```

This type is re-exported from the `./compiler` entry point and published in the `.d.ts` files under `dist/typescript/`. However, `@types/debug` is listed in `devDependencies`, so it's not installed for consumers. The `debug` package itself ships no type declarations.

Consumers with `skipLibCheck: false` get:

```
error TS7016: Could not find a declaration file for module 'debug'.
```

This affects all NativeWind users because `nativewind/metro` imports `react-native-css/metro`, which transitively imports the compiler module:

```
metro.config.ts
  → nativewind/metro
    → react-native-css/metro
      → react-native-css/compiler
        → compiler.types.d.ts: import type { Debugger } from "debug"
```

## Fix

Move `@types/debug` from `devDependencies` to `dependencies`. `debug` is already a runtime dependency — its type declarations should follow.

## Test plan

- [x] `yarn typecheck` — pass
- [x] `yarn lint` — pass
- [x] `yarn build` — pass (module + commonjs + typescript)
- [x] `yarn test` — 969 passed, 3 pre-existing failures in babel plugin tests (unrelated)
- [x] No unstaged files after build
- [x] Verified in isolated consumer project: error reproduces without `@types/debug`, resolves with it installed
