### PR TITLE
fix: propagate inlineRem and Metro config to compiler (Tailwind v4) (#316)

### DIFF
--- a/src/__tests__/native/units.test.tsx
+++ b/src/__tests__/native/units.test.tsx
@@ -148,6 +148,23 @@ test("rem - css root font-size override", () => {
   });
 });
 
+test("rem - via var() inlining picks up css root font-size ", () => {
+  registerCSS(`
+    :root { font-size: 16px; --text-base: 1rem; }
+    .text-base { font-size: var(--text-base); }
+  `);
+
+  const { result } = renderHook(() => {
+    return useNativeCss(View, { className: "text-base" });
+  });
+
+  expect(result.current.type).toBe(VariableContext.Provider);
+  expect(result.current.props.children.type).toBe(View);
+  expect(result.current.props.children.props).toStrictEqual({
+    style: { fontSize: 16 },
+  });
+});
+
 test("rem - css override", () => {
   registerCSS(
     `

--- a/src/compiler/compiler.ts
+++ b/src/compiler/compiler.ts
@@ -92,6 +92,7 @@ export function compile(code: Buffer | string, options: CompilerOptions = {}) {
     const css = typeof code === "string" ? code : code.toString();
     const match = css.match(/:root\s*\{[^}]*font-size:\s*([\d.]+)px/);
     effectiveRem = match?.[1] ? parseFloat(match[1]) : 14;
+    options.inlineRem = effectiveRem;
   }
 
   const firstPassVisitor: Visitor<CustomAtRules> = {};

--- a/src/metro/metro-transformer.ts
+++ b/src/metro/metro-transformer.ts
@@ -13,13 +13,13 @@ const worker =
   require(unstable_transformerPath) as typeof import("metro-transform-worker");
 
 export async function transform(
-  config: JsTransformerConfig,
+  config: JsTransformerConfig & {
+    reactNativeCSS?: CompilerOptions | undefined;
+  },
   projectRoot: string,
   filePath: string,
   data: Buffer,
-  options: JsTransformOptions & {
-    reactNativeCSS?: CompilerOptions | undefined;
-  },
+  options: JsTransformOptions,
 ): Promise<TransformResponse> {
   const isCss = options.type !== "asset" && /\.(s?css|sass)$/.test(filePath);
 
@@ -37,7 +37,7 @@ export async function transform(
   const css = cssFile.output[0].data.css.code.toString();
 
   const productionJS = compile(css, {
-    ...options.reactNativeCSS,
+    ...config.reactNativeCSS,
     filename: filePath,
     projectRoot: projectRoot,
   }).stylesheet();


### PR DESCRIPTION
## Summary

Fixes two related bugs that cause Tailwind v4's text utilities to render at the wrong size on native. Both manifest specifically on v4 and are benign on v3 — v3 emits direct `rem` values while v4 routes them through CSS custom properties, which traverse a different code path in the compiler.

## Bug 1 — Metro transformer drops `withReactNativeCSS` options

`withReactNativeCSS()` writes its options to `config.transformer.reactNativeCSS`, which Metro surfaces as `config.reactNativeCSS` inside the transformer. The transformer was instead spreading `options.reactNativeCSS` — a key that nothing ever writes to. `JsTransformOptions` is per-request context built by Metro's server (platform, dev, hot, etc.); `config.transformer.*` never flows into it.

**Result:** every option passed to `withReactNativeCSS` (including `inlineRem`) was silently dropped before reaching `compile()`.

## Bug 2 — regex-discovered `rem` isn't propagated downstream

`compile()` has a fallback that scans CSS for `:root { font-size: Npx }` when `inlineRem` isn't explicitly set, so users can configure rem scaling from CSS. The discovered value was only wired into the first-pass lightningcss `Length` visitor via a local `effectiveRem` — never written back into `options`. The second code path — `parseLength()` in `declarations.ts`, which reads `inlineRem` from `builder.getOptions()` — kept using the default `14`.

### Why v3 is unaffected

Tailwind v3 emits rem values directly:

​```css
.text-base { font-size: 1rem; line-height: 1.5rem; }
​```

The `1rem` is a proper lightningcss `Length` node, so the first-pass visitor handles it and scales correctly. The broken `parseLength` path is never exercised.

### Why v4 breaks

Tailwind v4 routes utility values through CSS custom properties:

​```css
:root { --text-base: 1rem; }
.text-base { font-size: var(--text-base); }
​```

The `1rem` inside the custom property is a token-list, inlined verbatim by `inlineVariables`, then resolved via `parseLength` in the second pass — where it reads the stale default.

see https://github.com/nativewind/react-native-css/blob/b5f2a4d5db480fdb8e8b95b3bd790d9d27b2dd17/src/compiler/declarations.ts#L1359-L1364

**Net effect on v4:** every `text-*` utility was sized against `rem=14` regardless of what `:root { font-size }` declared or what the user configured. Meanwhile direct rules like `.my-class { font-size: 1.5rem }` scaled correctly — which is why the bug evaded isolated tests.