### PR TITLE
fix: avoid walking ref props in styled mappings

### DIFF
--- a/src/runtime.types.ts
+++ b/src/runtime.types.ts
@@ -6,6 +6,7 @@ import type {
   ComponentType,
   ForwardRefExoticComponent,
   FunctionComponent,
+  PropsWithoutRef,
   ReactElement,
 } from "react";
 import type {
@@ -84,15 +85,15 @@ interface StyledConfigurationObject<
 > {
   target: T;
   nativeStyleMapping?: T extends false
-    ? NativeStyleMapping<string, ComponentProps<C>>
+    ? NativeStyleMapping<string, PropsWithoutRef<ComponentProps<C>>>
     : NativeStyleMapping<
         ResolveDotPath<T, ComponentProps<C>>,
-        ComponentProps<C>
+        PropsWithoutRef<ComponentProps<C>>
       >;
   /** @deprecated Please use nativeStyleMapping */
   nativeStyleToProp?: NativeStyleMapping<
     ResolveDotPath<T, ComponentProps<C>>,
-    ComponentProps<C>
+    PropsWithoutRef<ComponentProps<C>>
   >;
 }
 
@@ -119,7 +120,7 @@ export type ReactComponent<P = any> =
   | ForwardRefExoticComponent<P>;
 
 export type ComponentPropsDotNotation<C extends ReactComponent> = DotNotation<
-  ComponentProps<C>
+  PropsWithoutRef<ComponentProps<C>>
 >;
 
 /********************************    Styles    ********************************/


### PR DESCRIPTION
## Summary

Fixes a TypeScript performance issue where `styled()` can hang when wrapping components whose props include complex `ref` types, such as `react-strict-dom` elements.

`StyledConfiguration` currently computes dot-notation style targets from `ComponentProps<C>`. For components like `html.div`, that includes `ref?: React.Ref<HTMLDivElement>`. `DotNotation` then recursively walks into DOM element types through `ref`, which can make TypeScript hang.

This changes style-mapping target inference to use `PropsWithoutRef<ComponentProps<C>>`, while preserving `ref` on the returned styled component props.

Closes #343.

## Reproduction

Minimal repro: https://github.com/emmanuelchucks/react-native-css-styled-rsd-ref-repro

```tsx
import { html } from "react-strict-dom";
import { styled } from "react-native-css";

export const StyledDiv = styled(html.div, { className: "style" });
export const element = <StyledDiv className="p-4" />;
```

## Test plan

Ran locally:

```bash
yarn typecheck
yarn lint
yarn test --maxWorkers=2
yarn build
yarn example expo export --platform web
```

Also verified the `react-strict-dom` repro typechecks after the change.
