### PR TITLE
feat: add cursor CSS property support

### DIFF
--- a/src/__tests__/compiler/declarations.test.tsx
+++ b/src/__tests__/compiler/declarations.test.tsx
@@ -12,6 +12,8 @@ const tests = [
   ["rotate: x 3deg;", [{ d: [[[{}, "rotateX", "3deg"], "rotateX"]], s: [1, 1] }]],
   ["stroke-width: 1px;", [{ d: [[1, ["strokeWidth"]]], s: [1, 1] }]],
   ["stroke: black;", [{ d: [["#000", ["stroke"]]], s: [1, 1] }]],
+  ["cursor: pointer;", [{ d: [{ cursor: "pointer" }], s: [1, 1] }]],
+  ["cursor: auto;", [{ d: [{ cursor: "auto" }], s: [1, 1] }]],
 ] as const;
 
 test.each(tests)("declarations for %s", (declarations, expected) => {

--- a/src/__tests__/vendor/tailwind/interactivity.test.tsx
+++ b/src/__tests__/vendor/tailwind/interactivity.test.tsx
@@ -33,20 +33,17 @@ describe("Interactivity - Appearance", () => {
 describe("Interactivity - Cursor", () => {
   test("cursor-auto", async () => {
     expect(await renderCurrentTest()).toStrictEqual({
-      props: {},
-      warnings: { properties: ["cursor"] },
+      props: { style: { cursor: "auto" } },
     });
   });
   test("cursor-default", async () => {
     expect(await renderCurrentTest()).toStrictEqual({
-      props: {},
-      warnings: { properties: ["cursor"] },
+      props: { style: { cursor: "default" } },
     });
   });
-  test("cursor-default", async () => {
+  test("cursor-pointer", async () => {
     expect(await renderCurrentTest()).toStrictEqual({
-      props: {},
-      warnings: { properties: ["cursor"] },
+      props: { style: { cursor: "pointer" } },
     });
   });
 });

--- a/src/compiler/declarations.ts
+++ b/src/compiler/declarations.ts
@@ -157,6 +157,7 @@ const parsers: {
   "container": parseContainer,
   "container-name": parseContainerName,
   "container-type": parseContainerType,
+  "cursor": parseCursor,
   "display": parseDisplay,
   "direction": parseDirection,
   "fill": parseSVGPaint,
@@ -2534,6 +2535,10 @@ export function parseDimension(
       return;
     }
   }
+}
+
+function parseCursor({ value }: DeclarationType<"cursor">) {
+  return value.keyword;
 }
 
 export function parseUserSelect(


### PR DESCRIPTION
## Summary

Add compiler support for the CSS `cursor` property, enabling Tailwind classes like `cursor-pointer`, `cursor-auto`, and `cursor-default` to compile to the native `cursor` style prop.

This is targeted at **react-native-macos** and **react-native-windows**, which both support `cursor` as a native style property (via `StyleSheet.create` or inline styles). iOS and Android silently ignore the prop, so this change is safe cross-platform.

Currently, lightningcss parses `cursor` declarations correctly, but the compiler has no parser registered for it — the property is silently dropped with a warning. This PR fixes that.

Also fixes a duplicate `cursor-default` test in the Tailwind interactivity tests (replaced the second one with `cursor-pointer`).

## Implementation

The parser extracts `value.keyword` from the lightningcss `Cursor` AST (`{ images: CursorImage[], keyword: CursorKeyword }`). Only the keyword is used — cursor images (e.g. `cursor: url(...), pointer`) are not handled since React Native does not support custom cursor images.

Similar to `parseUserSelect` and `parsePointerEvents`.

## Test plan

- [x] Added compiler unit tests for `cursor: pointer;` and `cursor: auto;`
- [x] Updated Tailwind interactivity tests from expecting warnings to expecting style output
- [x] Fixed duplicate `cursor-default` test → `cursor-pointer`
- [x] All 1042 tests pass (`yarn test`)
- [x] Lint and typecheck pass (lefthook pre-commit)