### PR TITLE
fix: rename font-variant-caps to font-variant and parse font-variant

### DIFF
--- a/src/compiler/declarations.ts
+++ b/src/compiler/declarations.ts
@@ -62,6 +62,7 @@ type Parser<T extends Declaration["property"] = Declaration["property"]> = (
 
 const propertyRename: Record<string, string> = {
   "background-image": "experimental_backgroundImage",
+  "font-variant-caps": "font-variant",
 };
 
 const unparsedRuntimeParsing = new Set([
@@ -997,6 +998,18 @@ export function parseCustomDeclaration(
     );
   } else if (property === "corner-shape") {
     parseCornerShape(declaration.value, builder);
+  } else if (property === "font-variant") {
+    const parsedFontVariant = parseFontVariantCaps(
+      parseUnparsed(
+        declaration.value.value,
+        builder,
+        property,
+      ) as FontVariantCaps,
+      builder,
+    );
+    if (parsedFontVariant !== undefined) {
+      builder.addDescriptor(property, parsedFontVariant);
+    }
   } else if (
     validProperties.has(property) ||
     property.startsWith("--") ||


### PR DESCRIPTION
`font-variant` and `font-variant-caps` both were broken:

`font-variant-caps` was being parsed correctly by `parseFontVariantCapsDeclaration`, but it ended up as `fontVariantCaps` style, which is not correct, such a style doesn't exist in `react-native`. I added a rename for that.

To make `font-variant` work, I parsed it as a custom value (for some reason, it is treated as a custom value by `lightningcss`, and then treated it as `fontVariantCaps`)