### PR TITLE
fix: handle boolean shorthand in nativeStyleMapping

### DIFF
--- a/src/__tests__/native/components.test.tsx
+++ b/src/__tests__/native/components.test.tsx
@@ -1,4 +1,9 @@
-import { Button as RNButton, type ButtonProps } from "react-native";
+import {
+  Button as RNButton,
+  View as RNView,
+  type ButtonProps,
+  type ViewProps,
+} from "react-native";
 
 import { render } from "@testing-library/react-native";
 import { copyComponentProperties } from "react-native-css/components/copyComponentProperties";
@@ -53,4 +58,31 @@ test("Component preserves props when mapping specifies 'target: false'", () => {
   expect(titleElement.props.style).toBeInstanceOf(Array);
   expect(titleElement.props.style).toHaveLength(2);
   expect(titleElement.props.style[1]).toEqual({ color: "#ffa500" });
+});
+
+test("Component maps style onto a same-named prop when nativeStyleMapping uses the `true` shorthand", () => {
+  registerCSS(`.fill { background-color: red; }`);
+
+  const mapping: StyledConfiguration<typeof RNView> = {
+    className: {
+      target: "style",
+      nativeStyleMapping: {
+        backgroundColor: true,
+      },
+    },
+  };
+
+  const Component = copyComponentProperties(
+    RNView,
+    (props: StyledProps<ViewProps, typeof mapping>) => {
+      return useCssElement(RNView, props, mapping);
+    },
+  );
+
+  const result = render(<Component testID={testID} className="fill" />);
+
+  const renderedProps = result.getByTestId(testID).props;
+
+  expect(renderedProps.backgroundColor).toBe("#f00");
+  expect(renderedProps.style?.backgroundColor).toBeUndefined();
 });

--- a/src/native/styles/index.ts
+++ b/src/native/styles/index.ts
@@ -504,7 +504,7 @@ function nativeStyleMapping(
     }
 
     let target = props;
-    const tokens = path.split(".");
+    const tokens = (typeof path === "string" ? path : key).split(".");
     const lastToken = tokens.pop();
     for (const token of tokens) {
       target[token] ??= {};


### PR DESCRIPTION
## Summary

`nativeStyleMapping()` in `src/native/styles/index.ts` calls `path.split(".")` on every mapping value, but a value may be the boolean shorthand `true` — the same-name mapping permitted by the `NativeStyleMapping` type (`true | DotNotation`). When the mapped style is actually present, `(true).split` throws `TypeError: undefined is not a function`, crashing render.

Fixes #348 (same root cause as #232 / #288).

## Affected built-in components

Components that ship the boolean shorthand crash as soon as the mapped style is applied:

- `components/TextInput.tsx` → `{ textAlign: true }` — triggered by `text-right` / `text-center` / `text-left`
- `components/ImageBackground.tsx` → `{ backgroundColor: true }` — triggered by any `bg-*`

(`ActivityIndicator` / `Button` use `{ color: "color" }`, a string path, so they're unaffected.)

It only crashes when the mapped style is present: when absent, `styleValue === undefined` short-circuits via `continue`, which is why the crash looks intermittent.

## Fix

Treat `true` as the same-name shorthand (map onto a prop named `key`):

```ts
const tokens = (typeof path === "string" ? path : key).split(".");
```

## Test

Added a regression test in `src/__tests__/native/components.test.tsx` (using the `target: "style"` + `{ backgroundColor: true }` shorthand). It fails on `main` with `TypeError: path.split is not a function` and passes with this change.

`yarn test`, `yarn typecheck`, and `yarn lint` all pass.
