### PR TITLE
fix: remove transform keys before appending new ones

### DIFF
--- a/src/__tests__/native/transform.test.tsx
+++ b/src/__tests__/native/transform.test.tsx
@@ -45,10 +45,10 @@ describe("scale", () => {
 
   test("unparsed", () => {
     registerCSS(`
-      .my-class { 
+      .my-class {
         --scale-x: 2%;
         --scale-y: 2%;
-        scale: var(--scale-x) var(--scale-y); 
+        scale: var(--scale-x) var(--scale-y);
       }
     `);
     const component = render(
@@ -151,6 +151,26 @@ describe("transform", () => {
 
     expect(component.props.style).toStrictEqual({
       transform: [{ translateX: "10%" }, { scaleX: 2 }],
+    });
+  });
+
+  test.only("no duplicated translate objects", () => {
+    registerCSS(`
+.translate-x-1 {
+  --tw-translate-x: 4px;
+  transform: translate(var(--tw-translate-x), var(--tw-translate-y));
+}
+.translate-y-1 {
+  --tw-translate-y: 4px;
+  transform: translate(var(--tw-translate-x), var(--tw-translate-y));
+}`);
+
+    const component = render(
+      <View testID={testID} className="translate-x-1 translate-y-1" />,
+    ).getByTestId(testID);
+
+    expect(component.props.style).toStrictEqual({
+      transform: [{ translateX: 4 }, { translateY: 4 }],
     });
   });
 });

--- a/src/native/objects.ts
+++ b/src/native/objects.ts
@@ -69,10 +69,13 @@ export function applyValue(
 
     const transformArray: Record<string, unknown>[] = target.transform;
 
-    // Remove any existing values ​​and any keys that are to be appended next
-    target.transform = transformArray.filter((t) => !(prop in t));
+    // Remove any existing values and any keys that are to be appended next
     const keysToRemove = Array.isArray(value)
-      ? new Set(value.flatMap((v) => Object.keys(v)))
+      ? new Set(
+          value.flatMap((v) =>
+            v && typeof v === "object" ? Object.keys(v) : [],
+          ),
+        )
       : new Set([prop]);
     target.transform = transformArray.filter(
       (t) => !(prop in t) && !Object.keys(t).some((k) => keysToRemove.has(k)),

--- a/src/native/objects.ts
+++ b/src/native/objects.ts
@@ -69,8 +69,14 @@ export function applyValue(
 
     const transformArray: Record<string, unknown>[] = target.transform;
 
-    // Remove any existing values
+    // Remove any existing values ​​and any keys that are to be appended next
     target.transform = transformArray.filter((t) => !(prop in t));
+    const keysToRemove = Array.isArray(value)
+      ? new Set(value.flatMap((v) => Object.keys(v)))
+      : new Set([prop]);
+    target.transform = transformArray.filter(
+      (t) => !(prop in t) && !Object.keys(t).some((k) => keysToRemove.has(k)),
+    );
 
     if (Array.isArray(value)) {
       target.transform.push(...value);


### PR DESCRIPTION
This PR aims to remove doubled translate-related objects in the `transform` array, as described in #356 

Closes #356 