### PR TITLE
fix(compiler): map `color: inherit` to the inherited-color variable

### DIFF
--- a/src/__tests__/compiler/compiler.test.tsx
+++ b/src/__tests__/compiler/compiler.test.tsx
@@ -448,3 +448,121 @@ test("simplifies rem", () => {
     ],
   });
 });
+
+describe("CSS-wide color keywords", () => {
+  const stylesheetFor = (value: string) =>
+    compile(`.child { color: ${value}; }`).stylesheet();
+
+  test("compiles to the inherited-color variable instead of being dropped", () => {
+    // lightningcss emits `color: inherit` as an UnparsedProperty (the keyword is
+    // not a CssColor), which parseUnparsed used to drop. Per CSS Color,
+    // `currentcolor` used as the value of `color` is defined as `inherit`, so it
+    // resolves to the same inherited-color variable. The ABSENCE of a `v` entry
+    // is the no-self-reference guarantee — publishing this value as its own
+    // --__rn-css-color would seed a circular var(--__rn-css-color).
+    expect(stylesheetFor("inherit")).toStrictEqual({
+      s: [
+        [
+          "child",
+          [
+            {
+              s: [1, 1],
+              d: [[[{}, "var", "__rn-css-color"], "color", 1]],
+              dv: 1,
+            },
+          ],
+        ],
+      ],
+    });
+  });
+
+  test("inherit and currentcolor compile identically (CSS Color spec identity)", () => {
+    expect(stylesheetFor("inherit")).toStrictEqual(
+      stylesheetFor("currentcolor"),
+    );
+  });
+
+  test("currentcolor still resolves to the inherited-color variable (unchanged)", () => {
+    // The token/ident branch that hunk 1 restructured also carries currentcolor;
+    // this pins that currentcolor keeps compiling to the same lookup, and — like
+    // inherit — never self-publishes a `v`.
+    expect(stylesheetFor("currentcolor")).toStrictEqual({
+      s: [
+        [
+          "child",
+          [
+            {
+              s: [1, 1],
+              d: [[[{}, "var", "__rn-css-color"], "color", 1]],
+              dv: 1,
+            },
+          ],
+        ],
+      ],
+    });
+  });
+
+  test("a normal color still publishes --__rn-css-color to descendants", () => {
+    expect(stylesheetFor("red")).toStrictEqual({
+      s: [
+        [
+          "child",
+          [
+            {
+              s: [1, 1],
+              d: [{ color: "#f00" }],
+              v: [["__rn-css-color", "#f00"]],
+            },
+          ],
+        ],
+      ],
+    });
+  });
+
+  test("inherit on a non-color property is still dropped (no inheritance context)", () => {
+    expect(
+      compile(`.child { font-size: inherit; }`).stylesheet(),
+    ).toStrictEqual({});
+  });
+
+  test("color: initial is still dropped (different semantics, out of scope)", () => {
+    expect(stylesheetFor("initial")).toStrictEqual({});
+  });
+
+  test("color: unset resolves like inherit (unset on an inherited property is inherit)", () => {
+    // Per CSS Cascade, `unset` computes to `inherit` on inherited properties,
+    // and `color` is inherited — so it maps to the same inherited-color variable.
+    expect(stylesheetFor("unset")).toStrictEqual(stylesheetFor("inherit"));
+  });
+
+  test("keyword matching is case-insensitive (INHERIT)", () => {
+    // CSS-wide keywords are case-insensitive; lightningcss does not fold case.
+    expect(stylesheetFor("INHERIT")).toStrictEqual(stylesheetFor("inherit"));
+  });
+
+  test("currentColor (camelCase) resolves like currentcolor", () => {
+    // The spelling React/JS authors reach for; it is valid, case-insensitive CSS.
+    expect(stylesheetFor("currentColor")).toStrictEqual(
+      stylesheetFor("currentcolor"),
+    );
+  });
+
+  test("currentcolor resolves on a non-color property too (border-color)", () => {
+    expect(
+      compile(`.child { border-color: currentcolor; }`).stylesheet(),
+    ).toStrictEqual({
+      s: [
+        [
+          "child",
+          [
+            {
+              s: [1, 1],
+              d: [[[{}, "var", "__rn-css-color"], "borderColor", 1]],
+              dv: 1,
+            },
+          ],
+        ],
+      ],
+    });
+  });
+});

--- a/src/__tests__/compiler/compiler.test.tsx
+++ b/src/__tests__/compiler/compiler.test.tsx
@@ -553,6 +553,38 @@ describe("CSS-wide color keywords", () => {
     expect(stylesheetFor("initial")).toStrictEqual({});
   });
 
+  test.each([
+    ["background-color", "inherit"],
+    ["background-color", "initial"],
+    ["background-color", "revert"],
+    ["background-color", "revert-layer"],
+    ["border-color", "revert"],
+    ["font-size", "revert"],
+  ])("%s: %s is dropped on a non-color property too", (property, keyword) => {
+    // The drop arm is keyword-first, not property-first: only the RESOLVING
+    // arm is gated on `property === "color"`. `revert` and `revert-layer`
+    // previously fell through to the style as their literal string on every
+    // property, so this pins the widened drop across the property axis rather
+    // than on `color` alone.
+    expect(
+      compile(`.child { ${property}: ${keyword}; }`).stylesheet(),
+    ).toStrictEqual({});
+  });
+
+  test("unset on a non-color property is NOT dropped", () => {
+    // The exception to the arm above, and the reason `unset` is absent from it.
+    // On a non-inherited property `unset` means `initial`, and the literal left
+    // here is what the runtime clears the declared colour with — see
+    // `background-color: unset still clears the color` in
+    // src/__tests__/native/colors.test.tsx. Dropping it would take that away,
+    // and nothing else in the compiler would notice.
+    expect(
+      compile(`.child { background-color: unset; }`).stylesheet(),
+    ).toStrictEqual({
+      s: [["child", [{ s: [1, 1], d: [["unset", "backgroundColor"]] }]]],
+    });
+  });
+
   test("color: unset resolves like inherit (unset on an inherited property is inherit)", () => {
     // Per CSS Cascade, `unset` computes to `inherit` on inherited properties,
     // and `color` is inherited — so it maps to the same inherited-color variable.
@@ -749,6 +781,42 @@ describe("the inherited-color variable is never self-referential", () => {
       expected,
     ]);
   });
+
+  /**
+   * The discriminating half of the walk. Every one of these CONTAINS a `var()`
+   * — bare, with a fallback, and nested inside a function's argument list — but
+   * none of them names the inherited color, so every one must still publish.
+   *
+   * The census above cannot see this: each of its values resolves to a plain
+   * string, so a walk that answered "reads the inherited color" for ANY `var()`
+   * would leave it green. That mistake does not crash — it silently withholds
+   * the publish, and every descendant of a `color: var(--brand)` rule stops
+   * inheriting. These are the values that tell the two apart.
+   */
+  test.each<[value: string, published: StyleDescriptor[]]>([
+    ["var(--brand)", [[{}, "var", "brand", 1]]],
+    ["var(--brand, red)", [[{}, "var", ["brand", "red"], 1]]],
+    [
+      "color-mix(in srgb, var(--brand), blue)",
+      [
+        [
+          {},
+          "colorMix",
+          ["srgb", [{}, "var", "brand", 1], undefined, "blue", undefined],
+        ],
+      ],
+    ],
+    // light-dark() publishes from its own rule AND from the extra
+    // `prefers-color-scheme: dark` rule it pushes, so the census sees two.
+    ["light-dark(red, blue)", ["#f00", "#f00"]],
+  ])(
+    "color: %s names a variable that is not the inherited one, so it publishes",
+    (value, published) => {
+      expect(publishedInheritedColors(`.child { color: ${value}; }`)).toEqual(
+        published,
+      );
+    },
+  );
 
   test("light-dark() on color emits one dark rule, not one per parse", () => {
     // `light-dark()` pushes an extra `prefers-color-scheme: dark` rule as a

--- a/src/__tests__/compiler/compiler.test.tsx
+++ b/src/__tests__/compiler/compiler.test.tsx
@@ -585,6 +585,90 @@ describe("CSS-wide color keywords", () => {
     });
   });
 
+  /**
+   * The custom-property rows of the keyword table above, which cannot share its
+   * one-declaration template — see `uninlinedCustomProperty`.
+   *
+   * A custom property's value is a raw token stream with no property to inherit
+   * FROM and no per-property initial value to fall back to, so
+   * `property === "color"` is false and the resolving arm never fires for one.
+   * `currentcolor` is the exception, and it is not an exception to the gate:
+   * that arm is keyword-only, because `currentcolor` is valid on every
+   * property, custom ones included.
+   */
+  const uninlinedCustomProperty = (value: string) =>
+    // Two definitions, deliberately. react-native-css's own `inlineVariables`
+    // pass keys on a custom property's DECLARATION COUNT: a name declared once
+    // is folded into its consumer at compile time and the declaration is
+    // deleted, so a single-definition case never reaches the keyword arm as a
+    // custom property at all. The second definition is what puts it there —
+    // and it is why the `currentcolor` rows below expect TWO published values,
+    // one per declaring rule.
+    `.child { --brand: ${value}; color: var(--brand); }
+     .other { --brand: ${value}; }`;
+
+  test.each(["inherit", "initial", "revert", "revert-layer", "INHERIT"])(
+    "--brand: %s is dropped — a custom property has no property context",
+    (keyword) => {
+      expect(
+        publishedVariable(uninlinedCustomProperty(keyword), "brand"),
+      ).toEqual([]);
+    },
+  );
+
+  test.each(["currentcolor", "currentColor"])(
+    "--brand: %s resolves — the currentcolor arm is keyword-only, not property-gated",
+    (spelling) => {
+      // Also the vacuity guard for the drop rows above: same construction, so
+      // an empty result here would mean the inliner had eaten the declaration
+      // and the `[]` there was proving nothing.
+      //
+      // The camelCase spelling is the one THIS package folds — lightningcss
+      // hands a custom property's tokens through verbatim, so without the
+      // `.toLowerCase()` in parseUnparsed the literal string "currentColor" is
+      // published as the variable's value and every consumer renders that.
+      expect(
+        publishedVariable(uninlinedCustomProperty(spelling), "brand"),
+      ).toEqual([
+        [{}, "var", "__rn-css-color"],
+        [{}, "var", "__rn-css-color"],
+      ]);
+    },
+  );
+
+  test("--brand: unset keeps its literal, like unset on any non-color property", () => {
+    // `unset` is absent from the drop rows for the same reason it is absent
+    // from the keyword table: on anything that is not `color` it means
+    // `initial`, and the literal is what the runtime clears a value with.
+    expect(
+      publishedVariable(uninlinedCustomProperty("unset"), "brand"),
+    ).toEqual(["unset", "unset"]);
+  });
+
+  test("a custom property declared ONCE is folded into its consumer first", () => {
+    // Why the rows above declare `--brand` twice. With a single definition the
+    // inliner substitutes the value and deletes the declaration, so
+    // `color: var(--brand)` becomes `color: inherit` and takes the resolving
+    // arm — the opposite outcome from the identical CSS carrying one more
+    // definition of the same name.
+    expect(
+      compile(`.child { --brand: inherit; color: var(--brand); }`).stylesheet(),
+    ).toStrictEqual({
+      s: [
+        [
+          "child",
+          [
+            {
+              s: [1, 1],
+              d: [[[{}, "var", "__rn-css-color"], "color", 1]],
+              dv: 1,
+            },
+          ],
+        ],
+      ],
+    });
+  });
+
   test("color: unset resolves like inherit (unset on an inherited property is inherit)", () => {
     // Per CSS Cascade, `unset` computes to `inherit` on inherited properties,
     // and `color` is inherited — so it maps to the same inherited-color variable.
@@ -603,13 +687,33 @@ describe("CSS-wide color keywords", () => {
     },
   );
 
-  test("PIN: currentColor (camelCase) resolves like currentcolor", () => {
-    // A pin of behaviour that predates this change. Case folding here is
-    // lightningcss's, not ours — it parses either spelling into the same
-    // CssColor before this package sees it.
-    expect(stylesheetFor("currentColor")).toStrictEqual(
-      stylesheetFor("currentcolor"),
-    );
+  test("PIN: currentColor (camelCase) resolves to the inherited-color variable", () => {
+    // A pin of behaviour that predates this change. On the PARSED-color path
+    // the case fold is lightningcss's, not ours — it parses either spelling
+    // into the same CssColor before this package sees it.
+    //
+    // Asserted against the output rather than against
+    // `stylesheetFor("currentcolor")`. An equality between two spellings
+    // lightningcss has ALREADY folded holds whatever this package then does
+    // with the result, so it cannot fail: break `parseColor`'s currentcolor
+    // case and both sides move together while the sibling pin above goes red.
+    // The spelling this package folds itself is the one that reaches the ident
+    // branch — pinned by `--brand: currentColor` in the custom-property rows
+    // above, where the fold is ours and is new here.
+    expect(stylesheetFor("currentColor")).toStrictEqual({
+      s: [
+        [
+          "child",
+          [
+            {
+              s: [1, 1],
+              d: [[[{}, "var", "__rn-css-color"], "color", 1]],
+              dv: 1,
+            },
+          ],
+        ],
+      ],
+    });
   });
 
   test("PIN: currentcolor resolves on a non-color property too (border-color)", () => {
@@ -726,19 +830,25 @@ function declarationsFor(css: string): StyleDeclaration[] {
 }
 
 /**
- * Every value any rule in `css` publishes as `--__rn-css-color`.
+ * Every value any rule in `css` publishes as the custom property `name`, in
+ * compile order and once per publishing rule.
  *
  * Derived from the compiled output rather than restated, so a new rule shape
  * that publishes the variable is covered without editing the reader.
  */
-function publishedInheritedColors(css: string): StyleDescriptor[] {
+function publishedVariable(css: string, name: string): StyleDescriptor[] {
   return (compile(css).stylesheet().s ?? []).flatMap(([, ruleSet]) =>
     ruleSet.flatMap((rule) =>
       (rule.v ?? [])
-        .filter(([name]) => name === "__rn-css-color")
+        .filter(([varName]) => varName === name)
         .map(([, value]) => value),
     ),
   );
+}
+
+/** Every value any rule in `css` publishes as `--__rn-css-color`. */
+function publishedInheritedColors(css: string): StyleDescriptor[] {
+  return publishedVariable(css, "__rn-css-color");
 }
 
 describe("the inherited-color variable is never self-referential", () => {

--- a/src/__tests__/compiler/compiler.test.tsx
+++ b/src/__tests__/compiler/compiler.test.tsx
@@ -1,4 +1,8 @@
-import { compile } from "react-native-css/compiler";
+import {
+  compile,
+  type StyleDeclaration,
+  type StyleDescriptor,
+} from "react-native-css/compiler";
 
 test("hello world", () => {
   const compiled = compile(`
@@ -454,12 +458,14 @@ describe("CSS-wide color keywords", () => {
     compile(`.child { color: ${value}; }`).stylesheet();
 
   test("compiles to the inherited-color variable instead of being dropped", () => {
-    // lightningcss emits `color: inherit` as an UnparsedProperty (the keyword is
-    // not a CssColor), which parseUnparsed used to drop. Per CSS Color,
-    // `currentcolor` used as the value of `color` is defined as `inherit`, so it
-    // resolves to the same inherited-color variable. The ABSENCE of a `v` entry
-    // is the no-self-reference guarantee — publishing this value as its own
-    // --__rn-css-color would seed a circular var(--__rn-css-color).
+    // lightningcss emits `color: inherit` as an UnparsedProperty — the keyword
+    // is not a CssColor — so it lands in parseUnparsed's ident branch, which
+    // drops every keyword it has no resolution context for. Per CSS Color,
+    // `currentcolor` used as the value of `color` is defined as `inherit`, so
+    // both spell the same computed value and resolve to the same variable.
+    // The ABSENCE of a `v` entry is the no-self-reference guarantee: publishing
+    // this value as its own --__rn-css-color seeds a cycle a descendant then
+    // recurses into (see "never publishes a self-referential" below).
     expect(stylesheetFor("inherit")).toStrictEqual({
       s: [
         [
@@ -477,15 +483,20 @@ describe("CSS-wide color keywords", () => {
   });
 
   test("inherit and currentcolor compile identically (CSS Color spec identity)", () => {
+    // The two keywords travel different code paths — `inherit` through
+    // parseUnparsed's ident branch, `currentcolor` through parseColor — and
+    // must converge on the same output.
     expect(stylesheetFor("inherit")).toStrictEqual(
       stylesheetFor("currentcolor"),
     );
   });
 
-  test("currentcolor still resolves to the inherited-color variable (unchanged)", () => {
-    // The token/ident branch that hunk 1 restructured also carries currentcolor;
-    // this pins that currentcolor keeps compiling to the same lookup, and — like
-    // inherit — never self-publishes a `v`.
+  test("PIN: currentcolor resolves to the inherited-color variable", () => {
+    // A pin of behaviour that predates this change, not a guard for it:
+    // `color: currentcolor` never reaches the ident branch below. lightningcss
+    // parses it as a CssColor, so it is `parseColor`'s `case "currentcolor"`
+    // that produces this lookup and `parseFontColorDeclaration`'s own
+    // `type !== "currentcolor"` check that withholds the `v`.
     expect(stylesheetFor("currentcolor")).toStrictEqual({
       s: [
         [
@@ -502,7 +513,10 @@ describe("CSS-wide color keywords", () => {
     });
   });
 
-  test("a normal color still publishes --__rn-css-color to descendants", () => {
+  test("PIN: a normal color publishes --__rn-css-color to descendants", () => {
+    // A pin of behaviour that predates this change: `color: red` is a CssColor,
+    // so it is `parseFontColorDeclaration` that publishes the `v`. It is here
+    // because the guard added for the keywords must not swallow this case.
     expect(stylesheetFor("red")).toStrictEqual({
       s: [
         [
@@ -525,6 +539,16 @@ describe("CSS-wide color keywords", () => {
     ).toStrictEqual({});
   });
 
+  test("border-color: inherit is still dropped", () => {
+    // The near miss to the `property === "color"` gate: border-color IS a colour
+    // property, but it is not `color`, so it publishes nothing and inherits
+    // nothing. Only `color` seeds --__rn-css-color, so only `color` can read it
+    // back as `inherit`.
+    expect(
+      compile(`.child { border-color: inherit; }`).stylesheet(),
+    ).toStrictEqual({});
+  });
+
   test("color: initial is still dropped (different semantics, out of scope)", () => {
     expect(stylesheetFor("initial")).toStrictEqual({});
   });
@@ -535,19 +559,33 @@ describe("CSS-wide color keywords", () => {
     expect(stylesheetFor("unset")).toStrictEqual(stylesheetFor("inherit"));
   });
 
-  test("keyword matching is case-insensitive (INHERIT)", () => {
-    // CSS-wide keywords are case-insensitive; lightningcss does not fold case.
-    expect(stylesheetFor("INHERIT")).toStrictEqual(stylesheetFor("inherit"));
-  });
+  test.each(["INHERIT", "Inherit", "UNSET", "INITIAL"])(
+    "keyword matching is case-insensitive (%s)",
+    (spelling) => {
+      // CSS-wide keywords are case-insensitive; lightningcss does not fold case,
+      // so the ident branch has to. INITIAL is in the census because the fold
+      // must reach the drop-with-a-warning arm too, not only the resolving one.
+      expect(stylesheetFor(spelling)).toStrictEqual(
+        stylesheetFor(spelling.toLowerCase()),
+      );
+    },
+  );
 
-  test("currentColor (camelCase) resolves like currentcolor", () => {
-    // The spelling React/JS authors reach for; it is valid, case-insensitive CSS.
+  test("PIN: currentColor (camelCase) resolves like currentcolor", () => {
+    // A pin of behaviour that predates this change. Case folding here is
+    // lightningcss's, not ours — it parses either spelling into the same
+    // CssColor before this package sees it.
     expect(stylesheetFor("currentColor")).toStrictEqual(
       stylesheetFor("currentcolor"),
     );
   });
 
-  test("currentcolor resolves on a non-color property too (border-color)", () => {
+  test("PIN: currentcolor resolves on a non-color property too (border-color)", () => {
+    // A pin of behaviour that predates this change: border-color is a parsed
+    // CssColor, so this is parseColor's `case "currentcolor"` again. The ident
+    // branch's own currentcolor clause is what serves the UNPARSED properties —
+    // box-shadow, filter: drop-shadow(), and custom properties — and those are
+    // covered by src/__tests__/native/{box-shadow,filters}.test.tsx.
     expect(
       compile(`.child { border-color: currentcolor; }`).stylesheet(),
     ).toStrictEqual({
@@ -564,5 +602,164 @@ describe("CSS-wide color keywords", () => {
         ],
       ],
     });
+  });
+
+  test("color: inherit !important keeps the important specificity", () => {
+    expect(stylesheetFor("inherit !important")).toStrictEqual({
+      s: [
+        [
+          "child",
+          [
+            {
+              s: [1, 1, 1],
+              d: [[[{}, "var", "__rn-css-color"], "color", 1]],
+              dv: 1,
+            },
+          ],
+        ],
+      ],
+    });
+  });
+
+  test("color: inherit inside a media query keeps the condition", () => {
+    expect(
+      compile(
+        `@media (min-width: 100px) { .child { color: inherit; } }`,
+      ).stylesheet(),
+    ).toStrictEqual({
+      s: [
+        [
+          "child",
+          [
+            {
+              s: [2, 1],
+              m: [[">=", "width", 100]],
+              d: [[[{}, "var", "__rn-css-color"], "color", 1]],
+              dv: 1,
+            },
+          ],
+        ],
+      ],
+    });
+  });
+
+  test("color: inherit inside :hover keeps the pseudo-class condition", () => {
+    expect(
+      compile(`.child:hover { color: inherit; }`).stylesheet(),
+    ).toStrictEqual({
+      s: [
+        [
+          "child",
+          [
+            {
+              s: [1, 2],
+              d: [[[{}, "var", "__rn-css-color"], "color", 1]],
+              dv: 1,
+              p: { h: 1 },
+            },
+          ],
+        ],
+      ],
+    });
+  });
+
+  test.each([
+    ["placeholder", "placeholderTextColor"],
+    ["selection", "selectionColor"],
+  ])("color: inherit on ::%s targets %s", (pseudoElement, targetProp) => {
+    // A pseudo-element rule retargets the declaration off `style`, so the
+    // inherited-color lookup has to survive the retarget.
+    expect(
+      declarationsFor(`.child::${pseudoElement} { color: inherit; }`),
+    ).toStrictEqual([[[{}, "var", "__rn-css-color"], [targetProp], 1]]);
+  });
+
+  test.each(["revert", "revert-layer"])(
+    "color: %s is dropped rather than published as a literal",
+    (keyword) => {
+      // React Native has no cascade origins to revert to, so the keyword has no
+      // computed value here. Emitting the literal string put `color: "revert"`
+      // in the style AND published it as --__rn-css-color, handing every
+      // descendant that reads the inherited color an unusable value.
+      expect(stylesheetFor(keyword)).toStrictEqual({});
+    },
+  );
+});
+
+/** Every declaration every rule in `css` produces, in compile order. */
+function declarationsFor(css: string): StyleDeclaration[] {
+  return (compile(css).stylesheet().s ?? []).flatMap(([, ruleSet]) =>
+    ruleSet.flatMap((rule) => rule.d ?? []),
+  );
+}
+
+/**
+ * Every value any rule in `css` publishes as `--__rn-css-color`.
+ *
+ * Derived from the compiled output rather than restated, so a new rule shape
+ * that publishes the variable is covered without editing the reader.
+ */
+function publishedInheritedColors(css: string): StyleDescriptor[] {
+  return (compile(css).stylesheet().s ?? []).flatMap(([, ruleSet]) =>
+    ruleSet.flatMap((rule) =>
+      (rule.v ?? [])
+        .filter(([name]) => name === "__rn-css-color")
+        .map(([, value]) => value),
+    ),
+  );
+}
+
+describe("the inherited-color variable is never self-referential", () => {
+  /**
+   * Each of these makes `color` READ --__rn-css-color from somewhere below the
+   * top level of the descriptor, which is what a guard comparing only the top
+   * level misses. Publishing any of them as --__rn-css-color hands a descendant
+   * a value that resolves back into the same variable, and resolution recurses
+   * until the stack is exhausted.
+   */
+  const selfReferentialColors = [
+    "inherit",
+    "unset",
+    "currentcolor",
+    "var(--missing, inherit)",
+    "var(--missing, unset)",
+    "var(--missing, currentcolor)",
+    "color-mix(in srgb, currentcolor, blue)",
+    "color-mix(in srgb, inherit, blue)",
+    "rgb(from currentcolor r g b)",
+    "light-dark(currentcolor, blue)",
+  ];
+
+  test("the census is not empty", () => {
+    expect(selfReferentialColors.length).toBeGreaterThan(0);
+  });
+
+  test.each(selfReferentialColors)("color: %s publishes no `v`", (value) => {
+    expect(publishedInheritedColors(`.child { color: ${value}; }`)).toEqual([]);
+  });
+
+  test.each([
+    ["red", "#f00"],
+    ["#00f", "#00f"],
+    ["rgb(1 2 3)", "#010203"],
+    ["color-mix(in srgb, red, blue)", "#800080"],
+    ["oklch(0.7 0.1 200)", "#40b1b7"],
+  ])("color: %s still publishes its own resolved value", (value, expected) => {
+    expect(publishedInheritedColors(`.child { color: ${value}; }`)).toEqual([
+      expected,
+    ]);
+  });
+
+  test("light-dark() on color emits one dark rule, not one per parse", () => {
+    // `light-dark()` pushes an extra `prefers-color-scheme: dark` rule as a
+    // SIDE EFFECT of parsing, so the colour must be parsed exactly once for the
+    // declaration and the published variable both.
+    const darkRules = (
+      compile(`.child { color: light-dark(red, blue); }`).stylesheet().s ?? []
+    )
+      .flatMap(([, ruleSet]) => ruleSet)
+      .filter((rule) => rule.m !== undefined);
+
+    expect(darkRules).toHaveLength(1);
   });
 });

--- a/src/__tests__/native/colors.test.tsx
+++ b/src/__tests__/native/colors.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from "@testing-library/react-native";
+import { Text } from "react-native-css/components/Text";
 import { View } from "react-native-css/components/View";
 import { registerCSS, testID } from "react-native-css/jest";
 
@@ -162,6 +163,108 @@ describe("currentcolor", () => {
       children: undefined,
       style: { color: "#f00", backgroundColor: "#f00" },
       testID,
+    });
+  });
+});
+
+describe("inherit", () => {
+  test("color: inherit resolves to the parent's color", () => {
+    registerCSS(`
+      .parent { color: red; }
+      .child { color: inherit; }
+    `);
+
+    render(
+      <View testID="parent" className="parent">
+        <View testID="child" className="child" />
+      </View>,
+    );
+
+    expect(screen.getByTestId("child").props.style).toStrictEqual({
+      color: "#f00",
+    });
+  });
+
+  test("text-inherit: a child Text inherits its parent's color", () => {
+    // The shape that surfaced the bug: a labelled button whose label renders
+    // React Native's default color (black) on native instead of the button's
+    // foreground color, while web inherits correctly.
+    registerCSS(`
+      .button { color: white; }
+      .label { color: inherit; }
+    `);
+
+    render(
+      <View testID="button" className="button">
+        <Text testID="label" className="label" />
+      </View>,
+    );
+
+    expect(screen.getByTestId("label").props.style).toStrictEqual({
+      color: "#fff",
+    });
+  });
+
+  test("inherit chains through an inheriting ancestor without breaking the chain", () => {
+    // The middle node inherits and must NOT republish a circular
+    // --__rn-css-color, or the grandchild would fail to resolve the color.
+    registerCSS(`
+      .parent { color: red; }
+      .mid { color: inherit; }
+      .child { color: inherit; }
+    `);
+
+    render(
+      <View testID="parent" className="parent">
+        <View testID="mid" className="mid">
+          <View testID="child" className="child" />
+        </View>
+      </View>,
+    );
+
+    expect(screen.getByTestId("mid").props.style).toStrictEqual({
+      color: "#f00",
+    });
+    expect(screen.getByTestId("child").props.style).toStrictEqual({
+      color: "#f00",
+    });
+  });
+
+  test("inherit follows the nearest colored ancestor", () => {
+    registerCSS(`
+      .outer { color: red; }
+      .inner { color: blue; }
+      .child { color: inherit; }
+    `);
+
+    render(
+      <View className="outer">
+        <View className="inner">
+          <View testID="child" className="child" />
+        </View>
+      </View>,
+    );
+
+    expect(screen.getByTestId("child").props.style).toStrictEqual({
+      color: "#00f",
+    });
+  });
+
+  test("color: unset inherits the parent's color, same as inherit", () => {
+    // `unset` computes to `inherit` on inherited properties, and color is one.
+    registerCSS(`
+      .parent { color: red; }
+      .child { color: unset; }
+    `);
+
+    render(
+      <View testID="parent" className="parent">
+        <View testID="child" className="child" />
+      </View>,
+    );
+
+    expect(screen.getByTestId("child").props.style).toStrictEqual({
+      color: "#f00",
     });
   });
 });

--- a/src/__tests__/native/colors.test.tsx
+++ b/src/__tests__/native/colors.test.tsx
@@ -1,7 +1,8 @@
-import { fireEvent, render, screen } from "@testing-library/react-native";
+import { act, fireEvent, render, screen } from "@testing-library/react-native";
 import { Text } from "react-native-css/components/Text";
 import { View } from "react-native-css/components/View";
 import { registerCSS, testID } from "react-native-css/jest";
+import { colorScheme } from "react-native-css/runtime";
 
 describe("hsl", () => {
   test("inline", () => {
@@ -407,20 +408,116 @@ describe("inherit", () => {
     });
   });
 
-  test("border-color: inherit is dropped, it does not read the color variable", () => {
-    // Only `color` seeds --__rn-css-color, so only `color` can read it back.
+  test.each(["border-color", "background-color"])(
+    "%s: inherit is dropped, it does not read the color variable",
+    (property) => {
+      // Only `color` seeds --__rn-css-color, so only `color` can read it back.
+      // Neither of these inherits in CSS either, so there is nothing for them
+      // to have inherited even if a per-property context existed.
+      registerCSS(`
+        .parent { color: red; }
+        .child { ${property}: inherit; }
+      `);
+
+      render(
+        <View className="parent">
+          <View testID="child" className="child" />
+        </View>,
+      );
+
+      expect(screen.getByTestId("child").props.style).toBeUndefined();
+    },
+  );
+
+  test("background-color: unset still clears the color", () => {
+    // The counterpart to the drop above. `unset` on a non-inherited property
+    // means `initial`, and the literal the compiler leaves in place is what the
+    // runtime clears the declared colour with — so adding `unset` to the
+    // keyword drop would silently take away the only way to clear one. The
+    // cleared element keeps the KEY and loses the value, which is how a later
+    // rule overrides an earlier one here rather than merging with it.
     registerCSS(`
-      .parent { color: red; }
-      .child { border-color: inherit; }
+      .filled { background-color: red; }
+      .cleared { background-color: unset; }
     `);
 
     render(
-      <View className="parent">
+      <>
+        <View testID="filled" className="filled" />
+        <View testID="cleared" className="filled cleared" />
+      </>,
+    );
+
+    expect(screen.getByTestId("filled").props.style).toStrictEqual({
+      backgroundColor: "#f00",
+    });
+    expect(screen.getByTestId("cleared").props.style).toStrictEqual({
+      backgroundColor: undefined,
+    });
+  });
+
+  test("color: inherit with no colored ancestor falls back to the root seed", () => {
+    // Nothing publishes --__rn-css-color above this element, so the read lands
+    // on the value the root seeds it with: the platform's label colour. The
+    // failure this guards is not a wrong colour but an UNRESOLVED one — the
+    // pre-fix drop left `style` undefined and React Native painted its own
+    // default, and a read that resolved to nothing would do the same.
+    registerCSS(`.child { color: inherit; }`);
+
+    render(<View testID="child" className="child" />);
+
+    expect(screen.getByTestId("child").props.style).toStrictEqual({
+      color: { semantic: ["label", "labelColor"] },
+    });
+  });
+
+  test("inherit resolves an ancestor color that is itself a variable", () => {
+    // `--brand` has a single definition, so the compiler inlines it and the
+    // published inherited colour is already a resolved string.
+    registerCSS(`
+      .parent { --brand: #ff0000; color: var(--brand); }
+      .child { color: inherit; }
+    `);
+
+    render(
+      <View testID="parent" className="parent">
         <View testID="child" className="child" />
       </View>,
     );
 
-    expect(screen.getByTestId("child").props.style).toBeUndefined();
+    expect(screen.getByTestId("parent").props.style).toStrictEqual({
+      color: "#f00",
+    });
+    expect(screen.getByTestId("child").props.style).toStrictEqual({
+      color: "#f00",
+    });
+  });
+
+  test("inherit resolves an ancestor color from an UNINLINED variable", () => {
+    // A second definition of `--brand` stops the compiler inlining it, so the
+    // ancestor publishes the var() lookup itself rather than a resolved colour.
+    // The descendant must still end up with the ancestor's COMPUTED colour —
+    // which is what `readsInheritedColor` letting a non-inherited `var()`
+    // through is for. Asserted as an equality against the ancestor rather than
+    // a literal: the class is that the two agree, and the raw-token colour a
+    // named-colour custom property currently produces is not this fix's to pin.
+    registerCSS(`
+      .parent { --brand: #ff0000; color: var(--brand); }
+      .child { --brand: #0000ff; color: inherit; }
+    `);
+
+    render(
+      <View testID="parent" className="parent">
+        <View testID="child" className="child" />
+      </View>,
+    );
+
+    const parentColor = screen.getByTestId("parent").props.style.color;
+
+    expect(parentColor).toBeDefined();
+    expect(screen.getByTestId("child").props.style).toStrictEqual({
+      color: parentColor,
+    });
   });
 
   test("color: inherit alongside a box-shadow leaves no placeholder in the style", () => {
@@ -430,6 +527,36 @@ describe("inherit", () => {
     registerCSS(`
       .parent { color: red; }
       .child { color: inherit; box-shadow: 1px 1px blue; }
+    `);
+
+    render(
+      <View className="parent">
+        <View testID="child" className="child" />
+      </View>,
+    );
+
+    expect(screen.getByTestId("child").props.style).toStrictEqual({
+      color: "#f00",
+      boxShadow: [
+        {
+          offsetX: 1,
+          offsetY: 1,
+          blurRadius: 0,
+          spreadDistance: 0,
+          color: "#00f",
+        },
+      ],
+    });
+  });
+
+  test("color: currentcolor alongside a box-shadow leaves no placeholder either", () => {
+    // The same runtime defect with no `inherit` anywhere in the input. The
+    // stranded target is a property of how a rule's declarations are walked,
+    // not of the keyword that made the colour delayed — so this is the pin that
+    // survives if the calculate-props fix is split into its own change.
+    registerCSS(`
+      .parent { color: red; }
+      .child { color: currentcolor; box-shadow: 1px 1px blue; }
     `);
 
     render(
@@ -472,24 +599,67 @@ describe("inherit", () => {
     });
   });
 
-  test("color: revert publishes nothing to descendants", () => {
-    // React Native has no cascade origins, so `revert` has no computed value.
-    // Emitting the literal handed every descendant `color: "revert"`.
+  test.each(["revert", "revert-layer"])(
+    "color: %s publishes nothing to descendants",
+    (keyword) => {
+      // React Native has no cascade origins, so neither keyword has a computed
+      // value. Emitting the literal handed every descendant `color: "revert"`.
+      registerCSS(`
+        .parent { color: red; }
+        .mid { color: ${keyword}; }
+        .child { color: inherit; }
+      `);
+
+      render(
+        <View className="parent">
+          <View testID="mid" className="mid">
+            <View testID="child" className="child" />
+          </View>
+        </View>,
+      );
+
+      expect(screen.getByTestId("mid").props.style).toBeUndefined();
+      expect(screen.getByTestId("child").props.style).toStrictEqual({
+        color: "#f00",
+      });
+    },
+  );
+
+  test("a light-dark() ancestor is inherited by a descendant", () => {
     registerCSS(`
-      .parent { color: red; }
-      .mid { color: revert; }
+      .parent { color: light-dark(red, blue); }
       .child { color: inherit; }
     `);
 
     render(
-      <View className="parent">
-        <View testID="mid" className="mid">
-          <View testID="child" className="child" />
-        </View>
+      <View testID="parent" className="parent">
+        <View testID="child" className="child" />
       </View>,
     );
 
-    expect(screen.getByTestId("mid").props.style).toBeUndefined();
+    expect(screen.getByTestId("parent").props.style).toStrictEqual({
+      color: "#f00",
+    });
+    expect(screen.getByTestId("child").props.style).toStrictEqual({
+      color: "#f00",
+    });
+
+    act(() => {
+      colorScheme.set("dark");
+    });
+
+    // KNOWN DIVERGENCE, pinned at the current output rather than at the
+    // CSS-correct one — the same treatment the `rgb(from …)` census entry below
+    // gets. Per CSS the descendant computes to the ancestor's used colour, so
+    // both should be `#00f` here. `light-dark()` instead publishes
+    // --__rn-css-color from its LIGHT branch only: the extra
+    // `prefers-color-scheme: dark` rule carries the dark `color` declaration
+    // beside the light published value. It predates this change — it reproduces
+    // with the double-parse restored — so it is recorded, not fixed here, and a
+    // fix has to come back and update this expectation.
+    expect(screen.getByTestId("parent").props.style).toStrictEqual({
+      color: "#00f",
+    });
     expect(screen.getByTestId("child").props.style).toStrictEqual({
       color: "#f00",
     });

--- a/src/__tests__/native/colors.test.tsx
+++ b/src/__tests__/native/colors.test.tsx
@@ -520,6 +520,99 @@ describe("inherit", () => {
     });
   });
 
+  /**
+   * `color: var(--brand)` where the KEYWORD is the custom property's value.
+   *
+   * The two tests below are the same CSS but for one extra declaration of
+   * `--brand`, and they end at opposite outcomes, because `inlineVariables`
+   * keys on a custom property's DECLARATION COUNT:
+   *
+   * - declared once, the value is folded into its consumer at compile time and
+   *   the rule compiles as `color: <keyword>` — the property context exists and
+   *   `inherit` resolves;
+   * - declared twice or more, the fold is defeated, `var(--brand)` survives as
+   *   a runtime lookup, and the compiler meets the keyword on a CUSTOM property
+   *   instead, where there is no property to inherit from — so it drops and the
+   *   lookup resolves to nothing.
+   *
+   * Mapping `color: inherit` to the inherited-color variable reaches the folded
+   * route only: before it BOTH routes were broken, so pinning them together is
+   * what records that the split between them is new.
+   */
+  test("color: var(--brand) with --brand: inherit resolves when the variable is inlined", () => {
+    registerCSS(`
+      .parent { color: red; }
+      .child { --brand: inherit; color: var(--brand); }
+    `);
+
+    render(
+      <View className="parent">
+        <View testID="child" className="child" />
+      </View>,
+    );
+
+    expect(screen.getByTestId("child").props.style).toStrictEqual({
+      color: "#f00",
+    });
+  });
+
+  test("color: var(--brand) with --brand: inherit drops when the variable is NOT inlined", () => {
+    // The unfolded half of the pair, pinned at the current output rather than
+    // at the CSS-correct one. Per CSS the child computes to red here too. The
+    // keyword is not the only thing that would have to change to get there: a
+    // custom property would need to carry the property context of whatever
+    // consumes it, which is a resolver change, not a keyword-table one.
+    registerCSS(`
+      .parent { color: red; }
+      .child { --brand: inherit; color: var(--brand); }
+      .other { --brand: inherit; }
+    `);
+
+    render(
+      <View className="parent">
+        <View testID="child" className="child" />
+      </View>,
+    );
+
+    expect(screen.getByTestId("child").props.style).toStrictEqual({});
+  });
+
+  test.each([
+    ["currentcolor", "inlined"],
+    ["currentcolor", "uninlined"],
+    ["currentColor", "inlined"],
+    ["currentColor", "uninlined"],
+  ] as const)(
+    "color: var(--brand) with --brand: %s resolves on the %s route",
+    (spelling, route) => {
+      // The control for the pair above: `currentcolor` is resolved by a
+      // keyword-only arm, so it never needs a property context and is symmetric
+      // across the fold. The camelCase spelling is symmetric too only because
+      // parseUnparsed folds case: lightningcss hands a custom property's tokens
+      // through verbatim, so without that fold the uninlined route publishes
+      // the literal string "currentColor" as the variable's value and this
+      // element renders it as a colour.
+      const secondDefinition =
+        route === "uninlined" ? `.other { --brand: ${spelling}; }` : "";
+
+      registerCSS(`
+        .parent { color: red; }
+        .child { --brand: ${spelling}; color: var(--brand); }
+        ${secondDefinition}
+      `);
+
+      render(
+        <View className="parent">
+          <View testID="child" className="child" />
+        </View>,
+      );
+
+      expect(screen.getByTestId("child").props.style).toStrictEqual({
+        color: "#f00",
+      });
+    },
+  );
+
   test("color: inherit alongside a box-shadow leaves no placeholder in the style", () => {
     // The delayed-value placeholder `{ color: true }` is internal bookkeeping.
     // A rule whose LAST declaration walks into a nested target (a shadow object)

--- a/src/__tests__/native/colors.test.tsx
+++ b/src/__tests__/native/colors.test.tsx
@@ -423,6 +423,55 @@ describe("inherit", () => {
     expect(screen.getByTestId("child").props.style).toBeUndefined();
   });
 
+  test("color: inherit alongside a box-shadow leaves no placeholder in the style", () => {
+    // The delayed-value placeholder `{ color: true }` is internal bookkeeping.
+    // A rule whose LAST declaration walks into a nested target (a shadow object)
+    // must not strand the placeholder of an earlier delayed declaration.
+    registerCSS(`
+      .parent { color: red; }
+      .child { color: inherit; box-shadow: 1px 1px blue; }
+    `);
+
+    render(
+      <View className="parent">
+        <View testID="child" className="child" />
+      </View>,
+    );
+
+    expect(screen.getByTestId("child").props.style).toStrictEqual({
+      color: "#f00",
+      boxShadow: [
+        {
+          offsetX: 1,
+          offsetY: 1,
+          blurRadius: 0,
+          spreadDistance: 0,
+          color: "#00f",
+        },
+      ],
+    });
+  });
+
+  test("color: inherit alongside a text-shadow leaves no placeholder either", () => {
+    registerCSS(`
+      .parent { color: red; }
+      .child { color: inherit; text-shadow: 1px 1px 2px blue; }
+    `);
+
+    render(
+      <View className="parent">
+        <View testID="child" className="child" />
+      </View>,
+    );
+
+    expect(screen.getByTestId("child").props.style).toStrictEqual({
+      color: "#f00",
+      textShadowColor: "#00f",
+      textShadowOffset: { width: 1, height: 1 },
+      textShadowRadius: 2,
+    });
+  });
+
   test("color: revert publishes nothing to descendants", () => {
     // React Native has no cascade origins, so `revert` has no computed value.
     // Emitting the literal handed every descendant `color: "revert"`.

--- a/src/__tests__/native/colors.test.tsx
+++ b/src/__tests__/native/colors.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react-native";
+import { fireEvent, render, screen } from "@testing-library/react-native";
 import { Text } from "react-native-css/components/Text";
 import { View } from "react-native-css/components/View";
 import { registerCSS, testID } from "react-native-css/jest";
@@ -267,4 +267,239 @@ describe("inherit", () => {
       color: "#f00",
     });
   });
+
+  test.each(["UNSET", "INHERIT", "Inherit"])(
+    "color: %s is case-folded and inherits",
+    (spelling) => {
+      registerCSS(`
+        .parent { color: red; }
+        .child { color: ${spelling}; }
+      `);
+
+      render(
+        <View className="parent">
+          <View testID="child" className="child" />
+        </View>,
+      );
+
+      expect(screen.getByTestId("child").props.style).toStrictEqual({
+        color: "#f00",
+      });
+    },
+  );
+
+  test("color: INITIAL is case-folded into the drop, not into the lookup", () => {
+    registerCSS(`
+      .parent { color: red; }
+      .child { color: INITIAL; }
+    `);
+
+    render(
+      <View className="parent">
+        <View testID="child" className="child" />
+      </View>,
+    );
+
+    expect(screen.getByTestId("child").props.style).toBeUndefined();
+  });
+
+  test("a descendant override restarts the chain", () => {
+    registerCSS(`
+      .red { color: red; }
+      .blue { color: blue; }
+      .inherit { color: inherit; }
+    `);
+
+    render(
+      <View className="red">
+        <View testID="first" className="inherit">
+          <View className="blue">
+            <View testID="second" className="inherit" />
+          </View>
+        </View>
+      </View>,
+    );
+
+    expect(screen.getByTestId("first").props.style).toStrictEqual({
+      color: "#f00",
+    });
+    expect(screen.getByTestId("second").props.style).toStrictEqual({
+      color: "#00f",
+    });
+  });
+
+  test("color: inherit under a media query", () => {
+    registerCSS(`
+      .parent { color: red; }
+      @media (min-width: 1px) { .child { color: inherit; } }
+    `);
+
+    render(
+      <View className="parent">
+        <View testID="child" className="child" />
+      </View>,
+    );
+
+    expect(screen.getByTestId("child").props.style).toStrictEqual({
+      color: "#f00",
+    });
+  });
+
+  test("color: inherit under :hover", () => {
+    registerCSS(`
+      .parent { color: red; }
+      .child { color: blue; }
+      .child:hover { color: inherit; }
+    `);
+
+    render(
+      <View className="parent">
+        <View testID="child" className="child" />
+      </View>,
+    );
+
+    const child = screen.getByTestId("child");
+    expect(child.props.style).toStrictEqual({ color: "#00f" });
+
+    fireEvent(child, "hoverIn", {});
+    expect(screen.getByTestId("child").props.style).toStrictEqual({
+      color: "#f00",
+    });
+  });
+
+  test("color: inherit !important beats a normal color on the same element", () => {
+    registerCSS(`
+      .parent { color: red; }
+      .child { color: inherit !important; }
+      .override { color: blue; }
+    `);
+
+    render(
+      <View className="parent">
+        <View testID="child" className="child override" />
+      </View>,
+    );
+
+    expect(screen.getByTestId("child").props.style).toStrictEqual({
+      color: "#f00",
+    });
+  });
+
+  test("color: inherit on ::placeholder and ::selection", () => {
+    registerCSS(`
+      .parent { color: red; }
+      .child::placeholder { color: inherit; }
+      .child::selection { color: inherit; }
+    `);
+
+    render(
+      <View className="parent">
+        <View testID="child" className="child" />
+      </View>,
+    );
+
+    expect(screen.getByTestId("child").props).toStrictEqual({
+      children: undefined,
+      placeholderTextColor: "#f00",
+      selectionColor: "#f00",
+      style: {},
+      testID: "child",
+    });
+  });
+
+  test("border-color: inherit is dropped, it does not read the color variable", () => {
+    // Only `color` seeds --__rn-css-color, so only `color` can read it back.
+    registerCSS(`
+      .parent { color: red; }
+      .child { border-color: inherit; }
+    `);
+
+    render(
+      <View className="parent">
+        <View testID="child" className="child" />
+      </View>,
+    );
+
+    expect(screen.getByTestId("child").props.style).toBeUndefined();
+  });
+
+  test("color: revert publishes nothing to descendants", () => {
+    // React Native has no cascade origins, so `revert` has no computed value.
+    // Emitting the literal handed every descendant `color: "revert"`.
+    registerCSS(`
+      .parent { color: red; }
+      .mid { color: revert; }
+      .child { color: inherit; }
+    `);
+
+    render(
+      <View className="parent">
+        <View testID="mid" className="mid">
+          <View testID="child" className="child" />
+        </View>
+      </View>,
+    );
+
+    expect(screen.getByTestId("mid").props.style).toBeUndefined();
+    expect(screen.getByTestId("child").props.style).toStrictEqual({
+      color: "#f00",
+    });
+  });
+});
+
+/**
+ * Each of these makes the middle element's `color` READ the inherited-color
+ * variable from below the top level of its descriptor. Publishing such a value
+ * as --__rn-css-color hands the child a value that resolves back into the same
+ * variable, and resolution recurses until the stack is exhausted.
+ *
+ * The middle element resolves against ITS parent, so the child sees the nearest
+ * ancestor that published a colour of its own — the red parent.
+ */
+const selfReferentialMiddleColors: [css: string, midColor: string][] = [
+  ["inherit", "#f00"],
+  ["unset", "#f00"],
+  ["currentcolor", "#f00"],
+  ["var(--missing, inherit)", "#f00"],
+  ["var(--missing, unset)", "#f00"],
+  ["var(--missing, currentcolor)", "#f00"],
+  ["color-mix(in srgb, currentcolor, blue)", "rgba(127.5, 0, 127.5, 1)"],
+  ["color-mix(in srgb, inherit, blue)", "rgba(127.5, 0, 127.5, 1)"],
+  ["light-dark(currentcolor, blue)", "#f00"],
+  // Relative colour syntax is not implemented, so the mid colour is the
+  // stringified function rather than a colour. It is here for the crash, and it
+  // pins the current output so that implementing `rgb(from …)` has to update it.
+  ["rgb(from currentcolor r g b)", "rgb(from, #f00, r, g, b)"],
+];
+
+describe("a color that reads the inherited color never publishes itself", () => {
+  test("the census is not empty", () => {
+    expect(selfReferentialMiddleColors.length).toBeGreaterThan(0);
+  });
+
+  test.each(selfReferentialMiddleColors)(
+    "mid { color: %s } renders, and its child inherits the grandparent's color",
+    (midColorValue, expectedMidColor) => {
+      registerCSS(`
+        .parent { color: red; }
+        .mid { color: ${midColorValue}; }
+        .child { color: inherit; }
+      `);
+
+      render(
+        <View className="parent">
+          <View testID="mid" className="mid">
+            <View testID="child" className="child" />
+          </View>
+        </View>,
+      );
+
+      expect(screen.getByTestId("mid").props.style).toStrictEqual({
+        color: expectedMidColor,
+      });
+      expect(screen.getByTestId("child").props.style).toStrictEqual({
+        color: "#f00",
+      });
+    },
+  );
 });

--- a/src/__tests__/native/colors.test.tsx
+++ b/src/__tests__/native/colors.test.tsx
@@ -654,9 +654,11 @@ describe("inherit", () => {
     // both should be `#00f` here. `light-dark()` instead publishes
     // --__rn-css-color from its LIGHT branch only: the extra
     // `prefers-color-scheme: dark` rule carries the dark `color` declaration
-    // beside the light published value. It predates this change — it reproduces
-    // with the double-parse restored — so it is recorded, not fixed here, and a
-    // fix has to come back and update this expectation.
+    // beside the light published value.
+    //
+    // It predates this change — it reproduces with the double parse restored —
+    // and it is #420's defect 2, so it is pinned here rather than fixed. Which
+    // of the two lands first decides who updates this expectation.
     expect(screen.getByTestId("parent").props.style).toStrictEqual({
       color: "#00f",
     });

--- a/src/__tests__/native/transform.test.tsx
+++ b/src/__tests__/native/transform.test.tsx
@@ -154,3 +154,55 @@ describe("transform", () => {
     });
   });
 });
+
+describe("a transform's target survives a later nested declaration", () => {
+  // A transform key resolves through a closure that runs after every
+  // declaration in the rule has been walked. A later declaration that walks
+  // into a NESTED target — a box-shadow entry is the one that reaches here —
+  // must not move the object those closures write into.
+  test("translate before a box-shadow still lands in transform", () => {
+    registerCSS(
+      `.my-class { translate: 10px 20px; box-shadow: 1px 1px blue; }`,
+    );
+
+    const component = render(
+      <View testID={testID} className="my-class" />,
+    ).getByTestId(testID);
+
+    expect(component.props.style).toStrictEqual({
+      transform: [{ translateX: 10 }, { translateY: 20 }],
+      boxShadow: [
+        {
+          offsetX: 1,
+          offsetY: 1,
+          blurRadius: 0,
+          spreadDistance: 0,
+          color: "#00f",
+        },
+      ],
+    });
+  });
+
+  test("declaration order does not matter", () => {
+    registerCSS(
+      `.my-class { box-shadow: 1px 1px blue; translate: 10px 20px; }`,
+    );
+
+    const component = render(
+      <View testID={testID} className="my-class" />,
+    ).getByTestId(testID);
+
+    expect(component.props.style).toStrictEqual({
+      transform: [{ translateX: 10 }, { translateY: 20 }],
+      boxShadow: [
+        {
+          offsetX: 1,
+          offsetY: 1,
+          blurRadius: 0,
+          spreadDistance: 0,
+          color: "#00f",
+        },
+      ],
+    });
+  });
+});

--- a/src/__tests__/vendor/tailwind/typography.test.tsx
+++ b/src/__tests__/vendor/tailwind/typography.test.tsx
@@ -322,9 +322,17 @@ describe("Typography - Text Color", () => {
     });
   });
   test("text-inherit", async () => {
+    // Per CSS Color, `inherit` on the `color` property is defined as
+    // `currentcolor`, so text-inherit resolves to the platform label color —
+    // identical to text-current above — instead of being dropped with a warning.
     expect(await renderCurrentTest()).toStrictEqual({
-      props: {},
-      warnings: { values: { color: "inherit" } },
+      props: {
+        style: {
+          color: {
+            semantic: ["label", "labelColor"],
+          },
+        },
+      },
     });
   });
 });

--- a/src/compiler/declarations.ts
+++ b/src/compiler/declarations.ts
@@ -950,20 +950,78 @@ export function parseUnparsedDeclaration(
     }
 
     if (property === "color") {
-      // Publish the resolved color to descendants as --__rn-css-color — the
-      // variable `currentcolor` and `color: inherit` both resolve against. Skip
-      // when the value IS that same lookup (e.g. `color: inherit`) so an
-      // inheriting rule never seeds a circular `--__rn-css-color:
-      // var(--__rn-css-color)` that would break resolution for its own subtree.
-      if (
-        !isStyleFunction(value) ||
-        value[1] !== "var" ||
-        value[2] !== "__rn-css-color"
-      ) {
-        builder.addDescriptor("--__rn-css-color", value);
-      }
+      publishInheritedColor(value, builder);
     }
   }
+}
+
+/** The variable a color rule publishes and `color: inherit` reads back. */
+const INHERITED_COLOR_VARIABLE = "__rn-css-color";
+
+/** A read of the inherited color, as `color: inherit` compiles to it. */
+const inheritedColorLookup = [
+  {},
+  "var",
+  INHERITED_COLOR_VARIABLE,
+] as const satisfies StyleFunction;
+
+/**
+ * Publish `value` to descendants as the inherited color, unless it reads the
+ * inherited color itself.
+ *
+ * A rule is handed to descendants as an UNRESOLVED descriptor, so a value that
+ * reads `--__rn-css-color` and is published under that same name resolves back
+ * into itself: the descendant recurses until the stack is exhausted. Withholding
+ * the publish leaves the nearest ancestor that names a color of its own as the
+ * one descendants inherit — which is exactly right for `inherit`, `unset` and
+ * `currentcolor`, and an approximation for a value that DERIVES from the
+ * inherited color (`color-mix(in srgb, currentcolor, blue)`), where descendants
+ * see the ancestor's color rather than the derived one. Publishing the derived
+ * value is only possible once resolution happens in the publisher's own scope.
+ */
+function publishInheritedColor(
+  value: StyleDescriptor,
+  builder: StylesheetBuilder,
+) {
+  if (readsInheritedColor(value)) {
+    return;
+  }
+
+  builder.addDescriptor(`--${INHERITED_COLOR_VARIABLE}`, value);
+}
+
+/**
+ * Whether `value` reads `var(--__rn-css-color)` anywhere inside it.
+ *
+ * The read is not always at the top level. `var(--brand, inherit)` buries it in
+ * a fallback, `color-mix(in srgb, currentcolor, blue)` and
+ * `rgb(from currentcolor r g b)` bury it in an argument list, and
+ * `light-dark(currentcolor, blue)` returns it from a branch — so the whole
+ * descriptor tree is walked rather than its first level.
+ */
+function readsInheritedColor(value: StyleDescriptor): boolean {
+  if (!Array.isArray(value)) {
+    return false;
+  }
+
+  if (isStyleFunction(value)) {
+    const args = value[2];
+
+    if (value[1] === "var") {
+      // `var()`'s arguments are the name alone, or `[name, fallback]`.
+      const name = Array.isArray(args) ? args[0] : args;
+
+      if (name === INHERITED_COLOR_VARIABLE) {
+        return true;
+      }
+    }
+
+    // A style function's other slots are its marker object, its name and the
+    // delayed-resolution flag; only the arguments can nest a descriptor.
+    return readsInheritedColor(args);
+  }
+
+  return value.some((entry) => readsInheritedColor(entry));
 }
 
 export function parseCustomDeclaration(
@@ -1268,7 +1326,8 @@ export function parseUnparsed(
             return;
           }
 
-          // CSS-wide keywords and `currentcolor` are case-insensitive.
+          // CSS-wide keywords and `currentcolor` are case-insensitive, and
+          // lightningcss hands them through unfolded.
           const keyword = value.toLowerCase();
 
           // Per CSS Color, `currentcolor` as the value of `color` is defined as
@@ -1276,20 +1335,35 @@ export function parseUnparsed(
           // (`color` is inherited) computes to `inherit` too. So `currentcolor`
           // (valid on any property) and `inherit` / `unset` on `color` all
           // resolve to the inherited-color variable every color rule publishes
-          // to its subtree (see parseUnparsedDeclaration).
+          // to its subtree (see publishInheritedColor).
+          //
+          // `color: currentcolor` does not arrive here — lightningcss parses it
+          // into a CssColor, so parseColor handles it. This clause serves the
+          // UNPARSED properties: box-shadow, filter: drop-shadow(), and custom
+          // properties, whose values reach the compiler as raw tokens.
           if (
             keyword === "currentcolor" ||
             ((keyword === "inherit" || keyword === "unset") &&
               property === "color")
           ) {
-            return [{}, "var", "__rn-css-color"] as const;
+            return inheritedColorLookup;
           }
 
-          // `inherit` and `initial` on any other property have no per-property
-          // resolution context here — drop with a warning. `unset` on a
-          // non-color property (= `initial` there) and `revert` /
-          // `revert-layer` keep their existing fall-through handling below.
-          if (keyword === "inherit" || keyword === "initial") {
+          // `inherit` on any other property has no per-property inheritance
+          // context here, `initial` has no per-property initial value, and
+          // React Native has no cascade origins for `revert` / `revert-layer`
+          // to roll back to. None of them has a value to compile to, so they
+          // drop with a warning rather than reaching the style as a literal.
+          //
+          // `unset` on a non-color property is the exception: it means
+          // `initial` there, and the runtime already turns the literal into
+          // `null`, which is how `background-color: unset` clears a color.
+          if (
+            keyword === "inherit" ||
+            keyword === "initial" ||
+            keyword === "revert" ||
+            keyword === "revert-layer"
+          ) {
             builder.addWarning("value", value);
             return;
           }
@@ -1613,17 +1687,13 @@ export function parseFontColorDeclaration(
   declaration: Extract<Declaration, { value: CssColor }>,
   builder: StylesheetBuilder,
 ) {
-  parseColorDeclaration(declaration, builder);
+  // Parsed once, for the declaration and the published variable both:
+  // `light-dark()` pushes an extra `prefers-color-scheme: dark` rule as a side
+  // effect, so a second parse emits a second copy of that rule.
+  const value = parseColor(declaration.value, builder);
 
-  if (
-    typeof declaration.value !== "object" ||
-    declaration.value.type !== "currentcolor"
-  ) {
-    builder.addDescriptor(
-      "--__rn-css-color",
-      parseColor(declaration.value, builder),
-    );
-  }
+  builder.addDescriptor(declaration.property, value);
+  publishInheritedColor(value, builder);
 }
 
 export function parseColorDeclaration(

--- a/src/compiler/declarations.ts
+++ b/src/compiler/declarations.ts
@@ -950,10 +950,15 @@ export function parseUnparsedDeclaration(
     }
 
     if (property === "color") {
+      // Publish the resolved color to descendants as --__rn-css-color — the
+      // variable `currentcolor` and `color: inherit` both resolve against. Skip
+      // when the value IS that same lookup (e.g. `color: inherit`) so an
+      // inheriting rule never seeds a circular `--__rn-css-color:
+      // var(--__rn-css-color)` that would break resolution for its own subtree.
       if (
         !isStyleFunction(value) ||
         value[1] !== "var" ||
-        value[2] !== "-css-color"
+        value[2] !== "__rn-css-color"
       ) {
         builder.addDescriptor("--__rn-css-color", value);
       }
@@ -1263,11 +1268,30 @@ export function parseUnparsed(
             return;
           }
 
-          if (value === "inherit" || value === "initial") {
+          // CSS-wide keywords and `currentcolor` are case-insensitive.
+          const keyword = value.toLowerCase();
+
+          // Per CSS Color, `currentcolor` as the value of `color` is defined as
+          // `inherit`; and per CSS Cascade, `unset` on an inherited property
+          // (`color` is inherited) computes to `inherit` too. So `currentcolor`
+          // (valid on any property) and `inherit` / `unset` on `color` all
+          // resolve to the inherited-color variable every color rule publishes
+          // to its subtree (see parseUnparsedDeclaration).
+          if (
+            keyword === "currentcolor" ||
+            ((keyword === "inherit" || keyword === "unset") &&
+              property === "color")
+          ) {
+            return [{}, "var", "__rn-css-color"] as const;
+          }
+
+          // `inherit` and `initial` on any other property have no per-property
+          // resolution context here — drop with a warning. `unset` on a
+          // non-color property (= `initial` there) and `revert` /
+          // `revert-layer` keep their existing fall-through handling below.
+          if (keyword === "inherit" || keyword === "initial") {
             builder.addWarning("value", value);
             return;
-          } else if (value === "currentcolor") {
-            return [{}, "var", "__rn-css-color"] as const;
           }
 
           if (value === "true") {

--- a/src/compiler/declarations.ts
+++ b/src/compiler/declarations.ts
@@ -958,12 +958,14 @@ export function parseUnparsedDeclaration(
 /** The variable a color rule publishes and `color: inherit` reads back. */
 const INHERITED_COLOR_VARIABLE = "__rn-css-color";
 
-/** A read of the inherited color, as `color: inherit` compiles to it. */
-const inheritedColorLookup = [
-  {},
-  "var",
-  INHERITED_COLOR_VARIABLE,
-] as const satisfies StyleFunction;
+/**
+ * A read of the inherited color, as `currentcolor` and `color: inherit` both
+ * compile to it. A fresh tuple per call, because a descriptor is owned by the
+ * rule it lands in.
+ */
+function inheritedColorLookup() {
+  return [{}, "var", INHERITED_COLOR_VARIABLE] as const satisfies StyleFunction;
+}
 
 /**
  * Publish `value` to descendants as the inherited color, unless it reads the
@@ -1190,7 +1192,7 @@ export function parseUnparsed(
     } else if (tokenOrValue === "false") {
       return false;
     } else if (tokenOrValue === "currentcolor") {
-      return [{}, "var", "__rn-css-color"] as const;
+      return inheritedColorLookup();
     } else {
       return tokenOrValue;
     }
@@ -1346,7 +1348,7 @@ export function parseUnparsed(
             ((keyword === "inherit" || keyword === "unset") &&
               property === "color")
           ) {
-            return inheritedColorLookup;
+            return inheritedColorLookup();
           }
 
           // `inherit` on any other property has no per-property inheritance
@@ -1732,7 +1734,7 @@ export function parseColor(cssColor: CssColor, builder: StylesheetBuilder) {
 
   switch (cssColor.type) {
     case "currentcolor":
-      return [{}, "var", "__rn-css-color"] as const;
+      return inheritedColorLookup();
     case "light-dark": {
       const extraRule: StyleRule = {
         s: [],

--- a/src/native/styles/calculate-props.ts
+++ b/src/native/styles/calculate-props.ts
@@ -105,14 +105,20 @@ export function applyDeclarations(
   target: Record<string, any> = {},
   topLevelTarget = target,
 ) {
-  const originalTarget = target;
-
   for (const declaration of declarations) {
-    target = originalTarget;
+    /**
+     * Scoped to THIS declaration. The delayed and transform closures below
+     * capture it, and they run after every declaration has been walked — so a
+     * binding shared across iterations hands them whatever nested object the
+     * LAST declaration ended on (a shadow, a transform entry) instead of the
+     * target this declaration resolved. The placeholder then never matches, and
+     * `{ [prop]: true }` is left in the style.
+     */
+    let declarationTarget = target;
 
     if (!Array.isArray(declaration)) {
       // Static styles
-      Object.assign(target, declaration);
+      Object.assign(declarationTarget, declaration);
     } else {
       // Dynamic styles
       let value: any = declaration[0];
@@ -131,7 +137,7 @@ export function applyDeclarations(
         if (final) {
           if (first !== "&") {
             topLevelTarget[first] ??= {};
-            target = topLevelTarget[first];
+            declarationTarget = topLevelTarget[first];
           }
 
           let previousProp: string | number = first;
@@ -143,19 +149,19 @@ export function applyDeclarations(
 
               if (!Array.isArray(previousTarget[previousProp])) {
                 previousTarget[previousProp] = [];
-                target = previousTarget[previousProp];
+                declarationTarget = previousTarget[previousProp];
               }
             }
-            previousTarget = target;
+            previousTarget = declarationTarget;
             previousProp = prop;
 
-            target[prop] ??= {};
-            target = target[prop];
+            declarationTarget[prop] ??= {};
+            declarationTarget = declarationTarget[prop];
           }
 
           prop = final;
         } else {
-          target = topLevelTarget;
+          declarationTarget = topLevelTarget;
           prop = first;
         }
       } else {
@@ -186,19 +192,19 @@ export function applyDeclarations(
               renderGuards: guards,
               calculateProps,
             });
-            applyValue(target, prop, value);
+            applyValue(declarationTarget, prop, value);
           });
         } else {
           delayedStyles.push(() => {
-            if (getDeepPath(target, prop) === value) {
-              delete target[prop];
+            if (getDeepPath(declarationTarget, prop) === value) {
+              delete declarationTarget[prop];
               value = resolveValue(originalValue, get, {
                 inlineVariables,
                 inheritedVariables,
                 renderGuards: guards,
                 calculateProps,
               });
-              applyValue(target, prop, value);
+              applyValue(declarationTarget, prop, value);
             }
           });
         }
@@ -211,7 +217,7 @@ export function applyDeclarations(
         });
       }
 
-      applyValue(target, prop, value);
+      applyValue(declarationTarget, prop, value);
     }
   }
 }


### PR DESCRIPTION
## Summary

Two independent defects, both in how the inherited-color variable is handled. The first is the title's: `text-inherit` (`color: inherit`) renders correctly on web but falls back to React Native's default text color on native, so a dark surface with an inheriting label becomes black-on-black:

```tsx
<View className="bg-primary text-primary-foreground">
  <Text className="text-inherit">Label</Text>  {/* correct on web, black-on-black on native */}
</View>
```

The second I found while fixing the first, and it is worse: **`main` today crashes a render with `RangeError: Maximum call stack size exceeded`** for several ordinary colors. That one is independent of `inherit` and reproduces on stock `3.0.7` — details below.

A third, smaller divergence rides along on the same lines and is worth naming up front, because it is the one place the `currentColor` spelling React authors write reaches the compiler's own keyword handling: through a **custom property**. `--brand: currentColor` publishes the literal string `"currentColor"` as the variable's value on `main`, and every consumer renders that string as a color. The case fold added here resolves it. See [The same keywords on a custom property](#the-same-keywords-on-a-custom-property--two-routes-and-only-one-of-them-resolves), which also records — rather than hides — a route split this PR **opens** on `inherit`.

## Cause — web keeps the CSS, native drops it

The two runtimes handle `className` differently, and only native breaks:

- **Web** — [`web/api.tsx`'s `useCssElement`](https://github.com/nativewind/react-native-css/blob/f70c4024eca4885c575bd4f596ab301b0f91813a/src/web/api.tsx#L61-L65) assigns `{ $$css: true, className }` to `style`, so react-native-web applies the class name as a **real CSS class**. `color: inherit` is then resolved by the browser's own cascade — nothing is compiled.
- **Native** — there is no CSS engine, so [`compiler/declarations.ts`](https://github.com/nativewind/react-native-css/blob/f70c4024eca4885c575bd4f596ab301b0f91813a/src/compiler/declarations.ts) compiles each value to an RN style object. Its token/ident branch [treats `inherit` as unsupported and drops it](https://github.com/nativewind/react-native-css/blob/f70c4024eca4885c575bd4f596ab301b0f91813a/src/compiler/declarations.ts#L1266-L1271) with a warning, so the `<Text>` gets **no color at all** and RN's default wins.

## Fix 1 — map the inherited-color keywords to the variable

The native runtime already carries the mechanism. Because React Native doesn't inherit `color` across elements, every color rule [publishes `--__rn-css-color` down its subtree](https://github.com/nativewind/react-native-css/blob/f70c4024eca4885c575bd4f596ab301b0f91813a/src/compiler/declarations.ts#L952-L959), and `parseUnparsed` [already resolves `currentcolor` to it](https://github.com/nativewind/react-native-css/blob/f70c4024eca4885c575bd4f596ab301b0f91813a/src/compiler/declarations.ts#L1269). `color: inherit` just needs the same path — and it isn't an approximation: per [CSS Color 3 §4.4](https://www.w3.org/TR/css-color-3/#currentcolor), *"if the `currentColor` keyword is set on the `color` property itself, it is treated as `color: inherit`."* Same value, same descriptor.

```ts
const keyword = value.toLowerCase();
if (
  keyword === "currentcolor" ||
  ((keyword === "inherit" || keyword === "unset") && property === "color")
) {
  return inheritedColorLookup();
}
```

`unset` is included because it computes to `inherit` on inherited properties and `color` is inherited.

**The `.toLowerCase()` is load-bearing on two surfaces, not one.** On a declared property it serves `INHERIT` / `UNSET` / `INITIAL`, which lightningcss hands through unfolded. It also serves the only route by which the `currentColor` spelling reaches this branch at all: a custom property's value arrives as raw tokens, so `--brand: currentColor` is met here as a literal string rather than as a parsed `CssColor`. Written directly, `color: currentColor` never gets this far — lightningcss parses it and `parseColor` handles it, and the fold there is lightningcss's rather than ours.

## Fix 2 — a color that READS the inherited color must never publish itself

This is the crash, and it is not caused by fix 1 — it is reachable on `main` right now.

A rule's color is handed to descendants as an **unresolved** descriptor. So if a rule both reads `--__rn-css-color` and publishes itself as `--__rn-css-color`, a descendant resolving it walks straight back into the same name and recursion runs until the stack is exhausted. There were two guards against that and both inspected only the **top level** of the descriptor, which misses every value that buries the read one level down:

```css
color: color-mix(in srgb, currentcolor, blue)
color: light-dark(currentcolor, blue)
color: rgb(from currentcolor r g b)
color: var(--brand, currentcolor)
```

A parent with any of those plus a descendant reading the inherited color takes the app down. `readsInheritedColor` walks the whole descriptor tree instead, and one `publishInheritedColor` replaces both guards — `parseUnparsedDeclaration` for the keyword path and `parseFontColorDeclaration` for the parsed-`CssColor` path, which had its own narrower `type !== "currentcolor"` test and let `light-dark(currentcolor, …)` through.

Withholding the publish leaves the nearest ancestor naming a color of its own as the one descendants inherit. That is exactly right for `inherit`, `unset` and `currentcolor` — see the open question below for the case where it is an approximation.

Two smaller things ride along, because they sit on the same lines:

- `revert` / `revert-layer` reached the style as the literal string `"revert"` **and** were published under `--__rn-css-color`, so a descendant reading the inherited color got `color: "revert"`. React Native has no cascade origins to roll back to, so they now drop with a warning like `initial`.
- `parseFontColorDeclaration` parsed the color twice. `light-dark()` pushes an extra `prefers-color-scheme: dark` rule as a **side effect** of parsing, so `color: light-dark(a, b)` emitted that rule twice. It parses once now.

## Fix 3 — a declaration's style target is scoped to its own iteration

`applyDeclarations` walked the target path into a fresh binding per declaration, but that binding was the function's `target` **parameter**, reassigned each time around the loop. The delayed and transform closures capture it and run after every declaration has been walked, so they saw whatever nested object the LAST declaration ended on.

```css
.parent { color: red }
.child  { color: inherit; box-shadow: 1px 1px blue }
```

```diff
- { color: { color: true }, boxShadow: [...] }   /* the internal placeholder, in the style */
+ { color: "#f00",          boxShadow: [...] }
```

A transform key fails worse — the values land **inside the shadow object** and the transform array keeps its boolean placeholders:

```diff
  .my-class { translate: 10px 20px; box-shadow: 1px 1px blue }

- { transform: [{ translateX: true }, { translateY: true }],
-   boxShadow: [{ …, transform: [{ translateX: 10 }, { translateY: 20 }] }] }
+ { transform: [{ translateX: 10 }, { translateY: 20 }], boxShadow: [{ … }] }
```

`color: currentcolor` in place of `color: inherit` reaches the same bug, so **this is a general runtime defect, not an `inherit` one** — it is the one part of this PR I would happily split out, and its tests are written not to depend on `inherit` so that a split is clean.

## Keyword coverage on `color`

| value | result |
| --- | --- |
| `inherit`, `unset`, `currentcolor` (any case) | → `var(--__rn-css-color)`, the inherited color |
| `initial` | dropped — its own semantics (the platform default); a follow-up |
| `revert`, `revert-layer` | dropped, on every property — RN has no cascade origin to roll back to |
| `inherit` / `initial` on a non-color property | dropped — no per-property inheritance context exists on native |
| `unset` on a non-color property | **not** dropped — there it means `initial`, and the literal is what clears the color |

## The same keywords on a custom property — two routes, and only one of them resolves

A custom property is a non-color property as far as the keyword arm is concerned, so by the table above it drops. What makes it worth its own section is that **the same CSS reaches two different outcomes depending on a rule elsewhere in the sheet.** `inlineVariables` keys on a custom property's declaration COUNT: a name declared exactly once is folded into its consumer at compile time and its declaration deleted, so the keyword is met on `color` and the property context exists. Declare the same name twice and the fold is defeated, `var(--brand)` survives as a runtime lookup, and the keyword is met on the custom property, where there is nothing to inherit from.

Measured, `.parent { color: red }` above `.child { --brand: K; color: var(--brand) }`, where route B adds a second `.other { --brand: K }` to defeat the inliner. The cell is the child's rendered `props.style`:

| `--brand:` | route | `main` (`f70c402`) | this PR |
| --- | --- | --- | --- |
| `inherit` | A, folded | `undefined` — the whole `.child` rule compiles away | `{ color: "#f00" }` |
| `inherit` | B, unfolded | `{}` | `{}` |
| `currentcolor` | A, folded | `{ color: "#f00" }` | `{ color: "#f00" }` |
| `currentcolor` | B, unfolded | `{ color: "#f00" }` | `{ color: "#f00" }` |
| `currentColor` | A, folded | `{ color: "#f00" }` | `{ color: "#f00" }` |
| `currentColor` | B, unfolded | **`{ color: "currentColor" }`** | `{ color: "#f00" }` |

Two things follow, and I would rather state both than let a reader infer the flattering one:

- **`--brand: currentColor` is a second divergence this PR closes,** and it is the camelCase spelling's only non-trivial home. On `main` the unfolded route publishes the literal string as the variable's value and the element renders it; the `.toLowerCase()` is what makes the two routes agree.
- **The `inherit` split is NEW as of this PR.** On `main` both routes drop `inherit`, symmetrically and equally wrongly — the folded one by compiling the rule away entirely, the unfolded one by leaving a rule whose lookup resolves to nothing. This change reaches the folded route only, so afterwards A resolves and B still drops. The unfolded defect is old; the disagreement between the two is not. Closing it is not a keyword-table change — a custom property would have to carry the property context of whatever consumes it, which is a resolver change — so B is **pinned at its current output**, with the CSS-correct answer named in the test.

The published-value rows on the compiler plane, same construction (two declaring rules, hence two published entries):

| `--brand:` | `main` publishes | this PR publishes |
| --- | --- | --- |
| `inherit`, `initial` | nothing | nothing |
| `revert`, `revert-layer` | `["revert", "revert"]` — the literal | nothing |
| `INHERIT` | `["INHERIT", "INHERIT"]` — the literal | nothing |
| `currentcolor` | two `var(--__rn-css-color)` lookups | two `var(--__rn-css-color)` lookups |
| `currentColor` | `["currentColor", "currentColor"]` — the literal | two `var(--__rn-css-color)` lookups |
| `unset` | `["unset", "unset"]` | `["unset", "unset"]` |

`unset` is deliberately absent from the drop rows and stays a literal, for the same reason it is absent from the keyword table: on anything that is not `color` it means `initial`, and the literal is what the runtime clears a value with — the same contract `background-color: unset` relies on.

**Why these rows are not in the keyword table.** That table's template is `.child { ${property}: ${keyword}; }`, one declaration. For a custom property that compiles to `{}` **because the inliner deleted a once-declared name**, so a row there would be vacuously green even if the ident branch resolved `inherit` on a custom property. The rows use the two-definition construction in an adjacent block instead, cross-referenced from the table. The `currentcolor` rows are the **vacuity guard** for the drop rows: same construction, non-empty expected result, so an inliner change that ate the declarations turns them red rather than silently hollowing out the drops.

## Test plan

Every defect above is covered on **both** planes — the compiler output and a real render — and each test was mutation-proved: I broke the thing it guards, watched it go red for the right reason, and reverted. Reverting each fix in turn reddens, measured across the whole suite on the current head:

| revert | compiler red | native red |
| --- | --- | --- |
| the `inherit` mapping (fix 1) | 13 | 32 (+1 vendor) |
| the lowercase keyword fold | 6 | 5 |
| the descriptor-tree walk (fix 2) | 6 | 6, all `RangeError` |
| `parseFontColorDeclaration`'s publish guard | 1 | 1, `RangeError` |
| treating any `var()` as a read (over-eager walk) | 3 | 1 |
| the `revert` / `revert-layer` drop | 8 | 2 |
| the double parse of `light-dark()` | 2 | 0 — see below |
| the target scoping (fix 3) | 0 — see below | 5 |

The crash is proven **red-to-green rather than pinned as a `toThrow`**: the census renders a parent → mid → child chain for each input and asserts the resolved colors, and on the unfixed code six of those renders die with `RangeError: Maximum call stack size exceeded`.

Two rows are deliberately zero, and both are measurements rather than omissions. The `light-dark()` double parse is **compiler-only**: restoring it puts three rules on the element instead of two and changes no rendered style, so only the two compiler assertions redden. The target scoping is **native-only**: it lives in `src/native/styles/calculate-props.ts`, which the compiler never executes, so reverting it reddens five render tests and not one compiler test.

The vendor `text-inherit` test (`vendor/tailwind/typography.test.tsx`) had encoded the dropped-declaration behaviour (`props: {}, warnings: { color: "inherit" }`) and now asserts the resolved label color, identical to the passing `text-current`. Its `decoration-inherit` sibling still drops, which confirms the `color`-only scope.

### One pin asserts an absolute value, because the comparison it would otherwise make cannot fail

`PIN: currentColor (camelCase)` asserts the compiled output literally rather than comparing `stylesheetFor("currentColor")` against `stylesheetFor("currentcolor")`. Both of those spellings are folded by **lightningcss**, before this package runs, so the two sides of that equality move together whatever this package then does with the result — the assertion is structurally incapable of failing.

The counterfactual, since a claim like that is worth measuring rather than reasoning about. Mutate `parseColor`'s `case "currentcolor": return inheritedColorLookup()` to `return "#000"`:

- the absolute form goes **red**;
- the equality form stays **green**, while its own sibling pin one screen up goes red.

Note that **a revert-based check cannot detect this class at all**, by construction: reverting asks whether an assertion notices the new behaviour disappearing, never whether it notices anything. All four `PIN:` tests are green under a full revert of this branch, which is exactly what a pin of pre-existing behaviour should do — the other three say so in their comments, and none of them is evidence that the assertion can fail.

### Gates

`yarn test` on the current head: `Test Suites: 2 failed, 4 skipped, 53 passed, 55 of 59 total`, `Tests: 3 failed, 21 skipped, 1151 passed, 1175 total`.

The 3 are `react-native › plugin › 7.`, `react-native-web › plugin › 6.` and `17.` — Windows-only `babel-plugin-tester` cases that are not this branch's: they fail identically, same three names, with both changed source files reverted to `f70c402`, which is how every revert measurement below was taken. That is the stable baseline on a warm cache; on a cold one this machine also produces a load-dependent tail of whole-suite run failures (a jest transform-cache `EPERM`, which subtracts that suite's tests from the total rather than failing an assertion) that vanish on a re-run. Read the `Test Suites:` line, not just `Tests:`, before comparing totals. `yarn typecheck` and `yarn lint` pass.

## Known limits

**`--brand: initial` makes the consuming rule vanish silently on the folded route.** Measured on this branch:

```js
compile(`.child { --brand: initial; color: var(--brand); }`).stylesheet();
// {}         — and warnings() is {} too: no rule, no diagnostic

compile(`.child { --brand: initial; color: var(--brand); }
         .other { --brand: initial; }`).stylesheet();
// the rule survives as a runtime lookup, and a warning IS emitted
```

This is one layer earlier than anything here: `inlineVariables` carries its own "the value is `initial` → substitute `undefined`" special case, which fires before the compiler's keyword arm ever runs, and the route-dependence is the same declaration-count fold as above. It is adjacent to this PR rather than part of it, and fixing it needs a semantics decision first — what *should* `initial` mean for an unregistered custom property, given there is no `@property` descriptor to take an initial value from — so I have left it alone rather than attaching a rider to a keyword change.

**The unfolded custom-property route still drops `inherit`**, as the table above records. Pinned, not fixed, with the CSS-correct expectation named in the test comment.

## Open questions

1. **A derived color is a knowingly-approximate result.** Withholding the publish is exactly right for `inherit`, `unset` and `currentcolor`, and an approximation for a value that DERIVES from the inherited color: with `color: color-mix(in srgb, currentcolor, blue)` on a middle element, descendants see the ancestor's color rather than the mixed one. Publishing the derived value is only possible once resolution happens in the publisher's own scope, which the compiler cannot do. Two census entries pin the approximation rather than hide it — happy to change the call.
2. **Overlap with #420.** Covering `light-dark()` on the render plane turned up a divergence — under dark an ancestor renders `#00f` while a descendant declaring `inherit` gets `#f00` — and #420 already owns it as its defect 2. I have pinned it here as a known divergence rather than fixed it, so whichever of the two lands second updates the expectation. The double parse in `parseFontColorDeclaration` is fixed on both branches too (#420's defect 6), so that function will conflict on merge and either copy can be dropped — they are the same change. Happy to rebase onto #420, or to drop the double-parse hunk here, whichever suits the merge order.
3. **`rgb(from currentcolor r g b)` is pinned at its current non-implemented output** (`"rgb(from, #f00, r, g, b)"`), deliberately — it is in the census for the crash, not for relative-color support. Implementing relative color syntax must update that expectation.
4. **Fix 3 is a general runtime defect riding in a compiler-scoped PR.** It is independently reproducible with `currentcolor` and I am happy to split it into its own PR.
5. **`revert` / `revert-layer` change from emitting a literal to being dropped.** Observable, and outside the title's scope — but leaving them was actively harmful, since they were published as the inherited color.
6. **Is the `inherit` route split acceptable as a landing state?** It is strictly better than `main` — one of the two routes now works where neither did — but it is a disagreement that did not exist before, and I would rather you decide that than discover it. The alternative is holding this until a custom property can carry its consumer's property context, which is a much larger change.
