### PR TITLE
fix: expand logical padding to physical properties on native

### DIFF
--- a/src/native/styles/index.ts
+++ b/src/native/styles/index.ts
@@ -303,9 +303,60 @@ export function getStyledProps(
     for (const source of consumedSources) {
       delete result[source];
     }
+    if (result.style !== undefined) {
+      result.style = expandLogicalPadding(result.style);
+    }
   }
 
   return result;
+}
+
+/**
+ * Android's Fabric TextInput ignores logical padding (`paddingBlock` / `paddingInline`): the
+ * value is dropped and the EditText theme default (~21dp) stays, so `py-2` measures 42.67dp
+ * instead of 35.81dp on a real device. Tailwind compiles `py-*` / `px-*` to exactly those
+ * logical properties, so effectively every text input is affected.
+ *
+ * Rewriting call sites to `pt-*` / `pb-*` is not an option — a Tailwind class sorter collapses
+ * them back to `py-*`. Convert to physical properties here, once className resolution is done.
+ * Existing physical values win, so an explicit `paddingTop` is never overwritten.
+ */
+function expandLogicalPadding(style: unknown): unknown {
+  if (!style || typeof style !== "object") {
+    return style;
+  }
+
+  if (Array.isArray(style)) {
+    let changed = false;
+    const next = style.map((entry) => {
+      const expanded = expandLogicalPadding(entry);
+      if (expanded !== entry) {
+        changed = true;
+      }
+      return expanded;
+    });
+    return changed ? next : style;
+  }
+
+  const { paddingBlock, paddingInline } = style as Record<string, unknown>;
+  if (paddingBlock === undefined && paddingInline === undefined) {
+    return style;
+  }
+
+  const next: Record<string, unknown> = { ...style };
+  delete next.paddingBlock;
+  delete next.paddingInline;
+
+  if (paddingBlock !== undefined) {
+    next.paddingTop ??= paddingBlock;
+    next.paddingBottom ??= paddingBlock;
+  }
+  if (paddingInline !== undefined) {
+    next.paddingLeft ??= paddingInline;
+    next.paddingRight ??= paddingInline;
+  }
+
+  return next;
 }
 
 /**


### PR DESCRIPTION
Android's Fabric `TextInput` ignores logical padding (`paddingBlock` / `paddingInline`). The value is dropped and the EditText theme default (~21dp) stays, so a `py-2` input measures **42.67dp** on a real device instead of 35.81dp. Measured on a Samsung SM-M236L, density 2.625, RN 0.86.2 new architecture.

Tailwind compiles `py-*` / `px-*` to exactly those logical properties, so in practice nearly every text input is affected.

Rewriting call sites to `pt-*` / `pb-*` is not a workaround — a Tailwind class sorter (prettier-plugin-tailwindcss, oxfmt) collapses them straight back to `py-*`.

This expands logical padding to physical properties in `getStyledProps`, after className resolution, so it covers every path that produces a style. Existing physical values win, so an explicit `paddingTop` is never overwritten. Arrays are handled and the input object is returned unchanged when there is nothing to expand.