### PR TITLE
fix: do not apply container queries whose attribute condition cannot be evaluated

### DIFF
--- a/src/native/conditions/container-query.ts
+++ b/src/native/conditions/container-query.ts
@@ -47,9 +47,21 @@ export function testContainerQuery(
     return false;
   }
 
-  // if (query.a && !testAttributes(query.a, container.props, guards)) {
-  //   return false;
-  // }
+  if (query.a) {
+    // zeta: the container value is an effect getter and carries no props (see
+    // `containers[name] = state.ruleEffectGetter` in react/rules.ts), which is why upstream
+    // commented out the attribute test above. The side effect is that a `group-<attribute>:`
+    // rule becomes **unconditionally true whenever a container exists** — every enabled
+    // Button renders its label with `group-disabled:text-white/20`. A condition we cannot
+    // evaluate must not be applied.
+    //
+    // Consequence: `group-disabled:*` never applies on native. Pseudo conditions
+    // (`group-active:`, `group-hover:`) go through the query.p path below and are unaffected.
+    // The real fix is to also carry props on `containers[name]` so testAttributes works, but
+    // the container key doubles as the identity for the hover/active reactivity signals, so
+    // that touches the reactivity design.
+    return false;
+  }
 
   if (query.m && !testContainerMediaCondition(query.m, container, get)) {
     return false;


### PR DESCRIPTION
The attribute test in `testContainerQuery` is commented out because the value stored in `containers[name]` is `state.ruleEffectGetter` and carries no props:

```ts
// src/native/conditions/container-query.ts
// if (query.a && !testAttributes(query.a, container.props, guards)) {
//   return false;
// }
```

With the test gone the condition falls through as satisfied, so a `group-<attribute>:` rule applies **whenever a container exists at all**. Concretely, every enabled `<Button>` renders its label with `group-disabled:text-white/20` — the disabled styling is always on.

This bails out instead. `group-disabled:*` then never applies on native, which is the safer of the two wrong answers: a missing disabled tint rather than every control looking disabled. Pseudo conditions (`group-active:`, `group-hover:`) go through the `query.p` path and are unaffected.

The real fix is to also carry props on `containers[name]` so `testAttributes` can run, but the container key doubles as the identity for the hover/active/focus reactivity signals, and an attribute change on the parent has no signal to invalidate children — so that needs a reactivity design change. Happy to attempt it if you would prefer that direction.