### PR TITLE
fix(native): share the :root variable registries across a dual-package split

### DIFF
--- a/src/__tests__/native/root-variable-registry.test.ts
+++ b/src/__tests__/native/root-variable-registry.test.ts
@@ -1,0 +1,47 @@
+import {
+  resolveRootVariableRegistries,
+  rootVariables,
+  universalVariables,
+} from "../../native-internal/root";
+
+/**
+ * The `:root` registries are global, and created + seeded exactly once.
+ *
+ * The package's `exports` map splits `import` and `require` onto different
+ * builds, and Metro resolves that condition per requesting module — so a
+ * compiled-CommonJS dependency and first-party source bind different copies of
+ * `native-internal/root`. Module-scope registries made that two independent
+ * stores: a `:root` variable injected into one copy was invisible to the
+ * other, and the value silently fell back to its seed.
+ *
+ * `resolveRootVariableRegistries` is what a second copy of the module runs, so
+ * calling it directly reproduces the second copy without needing the module
+ * itself to be re-evaluated.
+ */
+test("the module's exports are the registries published on globalThis", () => {
+  const registries = globalThis.__react_native_css_root_variable_registries;
+
+  expect(registries).toBeDefined();
+  expect(rootVariables).toBe(registries?.root);
+  expect(universalVariables).toBe(registries?.universal);
+});
+
+test("a second copy resolves the same registries", () => {
+  // Captured BEFORE the call: comparing against the global afterwards passes
+  // even when the resolver replaces it, which is no assertion at all.
+  const before = globalThis.__react_native_css_root_variable_registries;
+
+  expect(resolveRootVariableRegistries()).toBe(before);
+});
+
+test("a second copy does not re-seed over an injected value", () => {
+  // The regression a `??=` on the registries ALONE would ship: the seeds run
+  // unconditionally, so a copy initialising AFTER the stylesheet inject
+  // clobbers a project's `:root { font-size: 16px }` back to 14 and rescales
+  // every rem-derived value to 87.5%.
+  expect(rootVariables("__rn-css-rem").get()).toBe(14);
+
+  rootVariables("__rn-css-rem").set([[16]]);
+
+  expect(resolveRootVariableRegistries().root("__rn-css-rem").get()).toBe(16);
+});

--- a/src/__tests__/native/root-variable-registry.test.ts
+++ b/src/__tests__/native/root-variable-registry.test.ts
@@ -1,23 +1,5 @@
-import {
-  resolveRootVariableRegistries,
-  rootVariables,
-  universalVariables,
-} from "../../native-internal/root";
+import { rootVariables, universalVariables } from "../../native-internal/root";
 
-/**
- * The `:root` registries are global, and created + seeded exactly once.
- *
- * The package's `exports` map splits `import` and `require` onto different
- * builds, and Metro resolves that condition per requesting module — so a
- * compiled-CommonJS dependency and first-party source bind different copies of
- * `native-internal/root`. Module-scope registries made that two independent
- * stores: a `:root` variable injected into one copy was invisible to the
- * other, and the value silently fell back to its seed.
- *
- * `resolveRootVariableRegistries` is what a second copy of the module runs, so
- * calling it directly reproduces the second copy without needing the module
- * itself to be re-evaluated.
- */
 test("the module's exports are the registries published on globalThis", () => {
   const registries = globalThis.__react_native_css_root_variable_registries;
 
@@ -26,22 +8,21 @@ test("the module's exports are the registries published on globalThis", () => {
   expect(universalVariables).toBe(registries?.universal);
 });
 
-test("a second copy resolves the same registries", () => {
-  // Captured BEFORE the call: comparing against the global afterwards passes
-  // even when the resolver replaces it, which is no assertion at all.
-  const before = globalThis.__react_native_css_root_variable_registries;
+test("a second copy of the module shares the registries and does not re-seed", async () => {
+  // jest.resetModules() gives a fresh module registry against the same globalThis, which
+  // is exactly the dual-package case: the exports map splits import and require onto
+  // different builds, so two copies of this file evaluate in one bundle
+  const firstCopy = await import("../../native-internal/root");
 
-  expect(resolveRootVariableRegistries()).toBe(before);
-});
+  expect(firstCopy.rootVariables("__rn-css-rem").get()).toBe(14);
+  firstCopy.rootVariables("__rn-css-rem").set([[16]]);
 
-test("a second copy does not re-seed over an injected value", () => {
-  // The regression a `??=` on the registries ALONE would ship: the seeds run
-  // unconditionally, so a copy initialising AFTER the stylesheet inject
-  // clobbers a project's `:root { font-size: 16px }` back to 14 and rescales
-  // every rem-derived value to 87.5%.
-  expect(rootVariables("__rn-css-rem").get()).toBe(14);
+  jest.resetModules();
+  const secondCopy = await import("../../native-internal/root");
 
-  rootVariables("__rn-css-rem").set([[16]]);
+  // The module body really re-ran, so the assertions below are about two copies
+  expect(secondCopy).not.toBe(firstCopy);
 
-  expect(resolveRootVariableRegistries().root("__rn-css-rem").get()).toBe(16);
+  expect(secondCopy.rootVariables).toBe(firstCopy.rootVariables);
+  expect(secondCopy.rootVariables("__rn-css-rem").get()).toBe(16);
 });

--- a/src/native-internal/root.ts
+++ b/src/native-internal/root.ts
@@ -40,16 +40,9 @@ declare global {
     | undefined;
 }
 
-/**
- * Create BOTH registries and seed them, as one step.
- *
- * Creating and seeding cannot be split. A bare `??=` on the registries alone
- * would leave the seeds running unconditionally, so a second copy initialising
- * AFTER the stylesheet inject re-runs `set([[14]])` and clobbers a project's
- * own `:root { font-size: 16px }` back to 14 — silently rescaling every
- * rem-derived value to 87.5%. Both registries live behind ONE global for the
- * same reason: two globals could be half-initialised.
- */
+// Creating and seeding are one step. Guarding only the creation leaves the seeds running
+// unconditionally, so a copy initialising after the stylesheet inject clobbers a project's
+// `:root { font-size: 16px }` back to 14
 function createRootVariableRegistries(): RootVariableRegistries {
   const registries: RootVariableRegistries = {
     root: rootVariableFamily(),
@@ -70,23 +63,13 @@ function createRootVariableRegistries(): RootVariableRegistries {
   return registries;
 }
 
-/**
- * The `:root` registries are GLOBAL.
- *
- * The package's `exports` map splits `import` and `require` onto different
- * builds and Metro resolves that condition per REQUESTING module, so a
- * compiled-CommonJS dependency and first-party source bind different copies of
- * this file. Every other stateful module here already guards against that
- * (`style-collection.ts`, `variables.tsx`); these two held runtime state and
- * did not, so a `:root` variable injected into one copy was invisible to the
- * other and the value silently fell back to its seed.
- */
-export function resolveRootVariableRegistries(): RootVariableRegistries {
-  return (globalThis.__react_native_css_root_variable_registries ??=
-    createRootVariableRegistries());
-}
+// Global, like style-collection.ts and variables.tsx: the exports map splits import and
+// require onto different builds and Metro resolves that per requesting module, so a
+// compiled-CommonJS dependency and first-party source bind different copies of this file
+globalThis.__react_native_css_root_variable_registries ??=
+  createRootVariableRegistries();
 
-const registries = resolveRootVariableRegistries();
-
-export const rootVariables = registries.root;
-export const universalVariables = registries.universal;
+export const rootVariables =
+  globalThis.__react_native_css_root_variable_registries.root;
+export const universalVariables =
+  globalThis.__react_native_css_root_variable_registries.universal;

--- a/src/native-internal/root.ts
+++ b/src/native-internal/root.ts
@@ -29,16 +29,64 @@ const rootVariableFamily = () => {
   });
 };
 
-export const rootVariables = rootVariableFamily();
-export const universalVariables = rootVariableFamily();
+interface RootVariableRegistries {
+  root: ReturnType<typeof rootVariableFamily>;
+  universal: ReturnType<typeof rootVariableFamily>;
+}
 
-rootVariables("__rn-css-rem").set([[14]]);
-// eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-rootVariables("__rn-css-color").set([
-  [
-    Platform.OS === "ios"
-      ? PlatformColor("label", "labelColor")
-      : PlatformColor("?attr/textColorPrimary", "SystemBaseHighColor"),
-  ],
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-] as any);
+declare global {
+  var __react_native_css_root_variable_registries:
+    | RootVariableRegistries
+    | undefined;
+}
+
+/**
+ * Create BOTH registries and seed them, as one step.
+ *
+ * Creating and seeding cannot be split. A bare `??=` on the registries alone
+ * would leave the seeds running unconditionally, so a second copy initialising
+ * AFTER the stylesheet inject re-runs `set([[14]])` and clobbers a project's
+ * own `:root { font-size: 16px }` back to 14 — silently rescaling every
+ * rem-derived value to 87.5%. Both registries live behind ONE global for the
+ * same reason: two globals could be half-initialised.
+ */
+function createRootVariableRegistries(): RootVariableRegistries {
+  const registries: RootVariableRegistries = {
+    root: rootVariableFamily(),
+    universal: rootVariableFamily(),
+  };
+
+  registries.root("__rn-css-rem").set([[14]]);
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+  registries.root("__rn-css-color").set([
+    [
+      Platform.OS === "ios"
+        ? PlatformColor("label", "labelColor")
+        : PlatformColor("?attr/textColorPrimary", "SystemBaseHighColor"),
+    ],
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  ] as any);
+
+  return registries;
+}
+
+/**
+ * The `:root` registries are GLOBAL.
+ *
+ * The package's `exports` map splits `import` and `require` onto different
+ * builds and Metro resolves that condition per REQUESTING module, so a
+ * compiled-CommonJS dependency and first-party source bind different copies of
+ * this file. Every other stateful module here already guards against that
+ * (`style-collection.ts`, `variables.tsx`); these two held runtime state and
+ * did not, so a `:root` variable injected into one copy was invisible to the
+ * other and the value silently fell back to its seed.
+ */
+export function resolveRootVariableRegistries(): RootVariableRegistries {
+  return (globalThis.__react_native_css_root_variable_registries ??=
+    createRootVariableRegistries());
+}
+
+const registries = resolveRootVariableRegistries();
+
+export const rootVariables = registries.root;
+export const universalVariables = registries.universal;


### PR DESCRIPTION
## Problem

When a bundle contains **both** builds — `dist/module` for ESM importers and `dist/commonjs` for CommonJS ones — the two copies get **separate `:root` variable registries**. The compiled stylesheet is injected exactly once, into whichever copy the app's `.css` module resolved. Every component resolving through the *other* copy then looks up `var(--anything)` in an empty registry, gets `undefined`, and silently renders with no value.

For a `className` colour that means the element falls back to React Native's default text colour — black on Android, invisible on any dark surface. Nothing errors; the class is found (the style registry IS shared), only its *value* resolves to nothing.

This reproduces in a stock Expo SDK 57 app for any component shipping compiled CommonJS. `expo-router`'s `<Link>` is the case that surfaced it.

### Measured

Android, dark theme, `text-danger-foreground` (`#fb2c36`), sampled from the rendered pixels rather than by eye:

```
before:  painted=rgb(0,0,0)      bg=rgb(22,22,25)   contrast=39.9    ← effectively invisible
after:   painted=rgb(251,44,54)  bg=rgb(22,22,25)   contrast=231.9
```

Both builds are genuinely in the graph — resolving each module's dependency map to its path in a real Metro dev bundle:

```
styles/global.css        -> dist/module/native-internal/index.js      ← stylesheet injected HERE
first-party .tsx source  -> dist/module/components/index.cjs          ← same copy, works
expo-router BaseExpoRouterLink.js -> dist/commonjs/components/index.cjs ← OTHER copy, empty registry
```

## Root cause

`src/native-internal/root.ts` creates its registries at module scope, so two copies of the module means two independent registries. `exports` splits `import`/`require` across builds and Metro resolves that condition per *requesting* module.

Two sibling modules already guard against exactly this — `native-internal/style-collection.ts` and `native-internal/variables.ts` both use `globalThis.… ??=`. `root.ts` was missed.

## Why the one-line `??=` is a regression

`root.ts` does not only create the registries, it **seeds** them (`__rn-css-rem`, and the platform `__rn-css-color`). `__rn-css-rem` is also set by the injected stylesheet — a project pinning `:root { font-size: 16px }` injects `[[16]]`. So a bare `globalThis.x ??= rootVariableFamily()` leaves the seeds running unconditionally, and a second copy initialising *after* the inject re-runs `set([[14]])` and clobbers 16 back to 14 — silently rescaling every rem-derived utility to 87.5%.

Creation and seeding therefore have to be one atomic, once-only step, which is what this does.

## Tests

Three added, each mutation-proven (I broke the fix and watched the assertion go red before trusting it). Suite, typecheck and lint sit at the pristine-`main` baseline.
