### PR TITLE
fix(compiler): scope ::selection / ::placeholder declarations to the pseudo-element

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,7 +246,7 @@ React Native has no pseudo-elements. It has two props that stand in for one decl
 
 `::selection { background-color }`, not `::selection { color }`. In CSS `color` inside `::selection` is the colour of the selected text and `background-color` is the band painted behind it; React Native's `selectionColor` is that band.
 
-Every other declaration inside a pseudo-element is dropped, and the compiler reports it:
+Every other declaration inside a pseudo-element is dropped:
 
 ```css
 .input::selection {
@@ -255,6 +255,8 @@ Every other declaration inside a pseudo-element is dropped, and the compiler rep
   width: 10px; /* dropped */
 }
 ```
+
+The compiler records each drop, but nothing in the Metro pipeline reads that record — a `expo start` build prints nothing, and the only thing you observe is that the declaration has no effect on native. Two places do read it: `compile()`, and a jest test through `registerCSS(css, { debug: true })`.
 
 ```js
 compile(css).warnings();

--- a/README.md
+++ b/README.md
@@ -235,6 +235,39 @@ This API only allows for setting CSS variables as primitive values. For more com
 > [!IMPORTANT]  
 > By using `VariableContext` you may need to disable the `inlineVariable` optimization
 
+## Pseudo-elements
+
+React Native has no pseudo-elements. It has two props that stand in for one declaration each, and `::selection` / `::placeholder` compile to those props:
+
+| CSS                                | React Native prop      | On a        |
+| ---------------------------------- | ---------------------- | ----------- |
+| `::selection { background-color }` | `selectionColor`       | `TextInput` |
+| `::placeholder { color }`          | `placeholderTextColor` | `TextInput` |
+
+`::selection { background-color }`, not `::selection { color }`. In CSS `color` inside `::selection` is the colour of the selected text and `background-color` is the band painted behind it; React Native's `selectionColor` is that band.
+
+Every other declaration inside a pseudo-element is dropped, and the compiler reports it:
+
+```css
+.input::selection {
+  background-color: red; /* → selectionColor */
+  color: white; /* dropped */
+  width: 10px; /* dropped */
+}
+```
+
+```js
+compile(css).warnings();
+// { values: { "::selection": ["color", "width"] } }
+```
+
+They are dropped rather than applied because a pseudo-element's declarations belong to the pseudo-element. Applying them to the host would paint the element itself — a `::selection { color }` would set the element's text colour, and through `currentColor` its whole subtree.
+
+> [!IMPORTANT]
+> This is native only. On web the CSS file is served to the browser unchanged, so `::selection` and `::placeholder` behave exactly as CSS specifies and no declaration is dropped. A rule that is meaningful on both platforms should say so in `background-color` for `::selection` and `color` for `::placeholder`; anything else styles the browser and nothing else.
+
+With Tailwind, the native prop comes from `selection:bg-*`. `selection:text-*` is `color` and is dropped on native, though it still works in a browser.
+
 ## Optimizations
 
 CSS is a dynamic styling language that use highly optimized engines that are not available in React Native. Instead, we optimize the styles to improve performance

--- a/README.md
+++ b/README.md
@@ -265,6 +265,16 @@ compile(css).warnings();
 
 They are dropped rather than applied because a pseudo-element's declarations belong to the pseudo-element. Applying them to the host would paint the element itself — a `::selection { color }` would set the element's text colour, and through `currentColor` its whole subtree.
 
+A custom property is dropped the same way, and for the same reason: it would land on the host as a variable and every descendant would read it.
+
+```css
+.input::selection {
+  --brand: blue; /* dropped, reported as "--brand" */
+}
+```
+
+With `inlineVariables` left on, a custom property declared once is substituted into its uses and its declaration removed before the pseudo-element is scoped at all — nothing reaches the pseudo-element, so nothing is dropped and nothing is reported. `inlineVariables: false`, the setting the `VariableContext` section above asks for, keeps every declaration, and that is where this drop costs the most.
+
 > [!IMPORTANT]
 > This is native only. On web the CSS file is served to the browser unchanged, so `::selection` and `::placeholder` behave exactly as CSS specifies and no declaration is dropped. A rule that is meaningful on both platforms should say so in `background-color` for `::selection` and `color` for `::placeholder`; anything else styles the browser and nothing else.
 

--- a/src/__tests__/compiler/pseudo-elements.test.ts
+++ b/src/__tests__/compiler/pseudo-elements.test.ts
@@ -1,7 +1,8 @@
-import { compile } from "react-native-css/compiler";
+import { compile, type CompilerOptions } from "react-native-css/compiler";
 
 import type { StyleRule } from "../../compiler/compiler.types";
 import {
+  compilerVariablePrefix,
   pseudoElementFieldPolicy,
   scopeRuleToPseudoElement,
 } from "../../compiler/pseudo-elements";
@@ -14,12 +15,17 @@ interface CompiledClass {
 
 /**
  * Reads the whole rule, not just `d`. A pseudo-element declaration reaches the element through
- * any field a declaration can set — `v` carries the --__rn-css-color / --__rn-css-em mirrors
- * declarations.ts writes beside `color` and `font-size`, `c` registers a named container, and
- * `a` / `dv` make the host animated or variable-driven
+ * any field a declaration can set — `v` carries authored custom properties alongside the
+ * --__rn-css-color / --__rn-css-em mirrors declarations.ts writes beside `color` and
+ * `font-size`, `c` registers a named container, and `a` / `dv` make the host animated or
+ * variable-driven
  */
-const compileFor = (css: string, className = "a"): CompiledClass => {
-  const compiled = compile(css);
+const compileFor = (
+  css: string,
+  className = "a",
+  options: CompilerOptions = {},
+): CompiledClass => {
+  const compiled = compile(css, options);
   const rules = (compiled
     .stylesheet()
     .s?.find(([name]) => name === className)?.[1] ?? []) as StyleRule[];
@@ -133,6 +139,59 @@ describe("::selection", () => {
     ).toStrictEqual({
       rules: [{ d: [["#f00", ["selectionColor"]]] }],
       warnings: { values: { "::selection": ["container"] } },
+    });
+  });
+
+  test("an authored custom property is dropped and reported", () => {
+    // A custom property is the one authored declaration that lands in `v` rather than `d`, so
+    // it is scoped out by the field policy rather than by the declaration loop, and the report
+    // has to reach it there. `inlineVariables: false` is the configuration the VariableContext
+    // section of the README asks for, which is where a dropped custom property costs the most
+    expect(
+      compileFor(
+        `.a::selection { background-color: #ff0000; --brand: blue; }`,
+        "a",
+        { inlineVariables: false },
+      ),
+    ).toStrictEqual({
+      rules: [{ d: [["#f00", ["selectionColor"]]] }],
+      warnings: { values: { "::selection": ["--brand"] } },
+    });
+  });
+
+  test("an authored custom property is dropped with the optimization left on", () => {
+    // Declared twice, so the inline-variables optimization keeps it rather than folding it
+    // into its single use. The drop is the pseudo-element's, not the optimization's
+    expect(
+      compileFor(
+        `.a::selection { background-color: #ff0000; --brand: blue; } .b { --brand: green; }`,
+      ),
+    ).toStrictEqual({
+      rules: [{ d: [["#f00", ["selectionColor"]]] }],
+      warnings: { values: { "::selection": ["--brand"] } },
+    });
+  });
+
+  test("a custom property the optimization inlines away is not reported", () => {
+    // Declared once, so inlining folds it into its uses and deletes the declaration before any
+    // rule is built. Nothing reached the pseudo-element, so nothing was dropped by it — the
+    // same thing happens to a custom property on a plain rule
+    expect(
+      compileFor(`.a::selection { background-color: #ff0000; --brand: blue; }`),
+    ).toStrictEqual({
+      rules: [{ d: [["#f00", ["selectionColor"]]] }],
+      warnings: {},
+    });
+  });
+
+  test("an authored custom property alone leaves no rule and still reports", () => {
+    expect(
+      compileFor(`.a::selection { --brand: blue; }`, "a", {
+        inlineVariables: false,
+      }),
+    ).toStrictEqual({
+      rules: [],
+      warnings: { values: { "::selection": ["--brand"] } },
     });
   });
 
@@ -316,6 +375,52 @@ describe("::placeholder", () => {
     ).toStrictEqual({
       rules: [],
       warnings: { values: { "::placeholder": ["backgroundColor"] } },
+    });
+  });
+
+  test("an authored custom property is dropped and reported", () => {
+    expect(
+      compileFor(`.a::placeholder { color: #ff0000; --brand: blue; }`, "a", {
+        inlineVariables: false,
+      }),
+    ).toStrictEqual({
+      rules: [{ d: [["#f00", ["placeholderTextColor"]]] }],
+      warnings: { values: { "::placeholder": ["--brand"] } },
+    });
+  });
+});
+
+describe("the compiler's own custom properties", () => {
+  test("every custom property the compiler mints carries the prefix the report filters on", () => {
+    // The report tells a mirror from an authored name by this prefix, and the mirrors are
+    // minted over in declarations.ts. Reading the names off a compiled rule ties the two ends
+    // together: renaming the namespace at either end turns this red rather than leaving the
+    // report to name the compiler's own variables on every pseudo-element rule that sets one
+    const minted = compileFor(
+      `.a { color: #ff0000; font-size: 40px; direction: rtl; }`,
+    )
+      .rules.flatMap((rule) => rule.v ?? [])
+      .map(([name]) => name);
+
+    // Without this the loop below would assert nothing if the mirrors ever stopped being minted
+    expect(minted.length).toBeGreaterThan(0);
+
+    expect(
+      minted.filter((name) => !name.startsWith(compilerVariablePrefix)),
+    ).toStrictEqual([]);
+  });
+
+  test("a mirror stays silent and the authored property beside it is reported", () => {
+    // `color` writes both: a `d` entry, reported as `color`, and a --__rn-css-color mirror the
+    // compiler minted itself. `--brand` is the only custom property the user wrote, so it is
+    // the only one worth naming — reporting the mirror too would add noise to every rule
+    expect(
+      compileFor(`.a::selection { color: #ff0000; --brand: blue; }`, "a", {
+        inlineVariables: false,
+      }),
+    ).toStrictEqual({
+      rules: [],
+      warnings: { values: { "::selection": ["color", "--brand"] } },
     });
   });
 });

--- a/src/__tests__/compiler/pseudo-elements.test.ts
+++ b/src/__tests__/compiler/pseudo-elements.test.ts
@@ -8,12 +8,8 @@ const rulesFor = (css: string, className: string): StyleRule[] => {
     []) as StyleRule[];
 };
 
-/**
- * A pseudo-element's declarations are scoped to the pseudo-element. The
- * compiler maps ONE declaration onto a React Native prop; every other one must
- * be DROPPED, not returned unchanged — returning it applies a `::selection`
- * declaration to the real element.
- */
+// The compiler maps one declaration onto a React Native prop and drops the rest;
+// returning an unmapped one applies a ::selection declaration to the real element
 describe("::selection", () => {
   test("background-color maps to selectionColor", () => {
     const rules = rulesFor(`.a::selection { background-color: #ff0000; }`, "a");
@@ -37,18 +33,16 @@ describe("::selection", () => {
   });
 
   test("color does not paint the element", () => {
-    // `color` inside ::selection is the selected TEXT colour, which React
-    // Native cannot express — mapping it to `selectionColor` would invert its
-    // meaning, so it is dropped rather than re-targeted.
+    // color here is the selected TEXT colour, which React Native cannot express;
+    // mapping it to selectionColor would invert its meaning
     const rules = rulesFor(`.a::selection { color: #ff0000; }`, "a");
 
     expect(rules[0]?.d ?? []).toStrictEqual([]);
   });
 
   test("a plain rule on the same class is untouched", () => {
-    // The control an over-broad fix breaks: only the pseudo-element's own
-    // declarations are scoped away.
-    // A plain rule keeps the static object form the compiler emits for it.
+    // The control an over-broad fix breaks: only a pseudo-element's own declarations
+    // are scoped away, and a plain rule keeps the static object form
     const rules = rulesFor(`.a { background-color: #ff0000; }`, "a");
 
     expect(rules[0]?.d).toStrictEqual([{ backgroundColor: "#f00" }]);

--- a/src/__tests__/compiler/pseudo-elements.test.ts
+++ b/src/__tests__/compiler/pseudo-elements.test.ts
@@ -1,0 +1,73 @@
+import { compile } from "react-native-css/compiler";
+
+import type { StyleRule } from "../../compiler/compiler.types";
+
+const rulesFor = (css: string, className: string): StyleRule[] => {
+  const result = compile(css).stylesheet();
+  return (result.s?.find(([name]) => name === className)?.[1] ??
+    []) as StyleRule[];
+};
+
+/**
+ * A pseudo-element's declarations are scoped to the pseudo-element. The
+ * compiler maps ONE declaration onto a React Native prop; every other one must
+ * be DROPPED, not returned unchanged — returning it applies a `::selection`
+ * declaration to the real element.
+ */
+describe("::selection", () => {
+  test("background-color maps to selectionColor", () => {
+    const rules = rulesFor(`.a::selection { background-color: #ff0000; }`, "a");
+
+    expect(rules[0]?.d).toStrictEqual([["#f00", ["selectionColor"]]]);
+  });
+
+  test("an unmapped declaration is dropped, not applied to the element", () => {
+    const rules = rulesFor(`.a::selection { width: 10px; }`, "a");
+
+    expect(rules[0]?.d ?? []).toStrictEqual([]);
+  });
+
+  test("an unmapped declaration beside a mapped one is still dropped", () => {
+    const rules = rulesFor(
+      `.a::selection { background-color: #ff0000; width: 10px; }`,
+      "a",
+    );
+
+    expect(rules[0]?.d).toStrictEqual([["#f00", ["selectionColor"]]]);
+  });
+
+  test("color does not paint the element", () => {
+    // `color` inside ::selection is the selected TEXT colour, which React
+    // Native cannot express — mapping it to `selectionColor` would invert its
+    // meaning, so it is dropped rather than re-targeted.
+    const rules = rulesFor(`.a::selection { color: #ff0000; }`, "a");
+
+    expect(rules[0]?.d ?? []).toStrictEqual([]);
+  });
+
+  test("a plain rule on the same class is untouched", () => {
+    // The control an over-broad fix breaks: only the pseudo-element's own
+    // declarations are scoped away.
+    // A plain rule keeps the static object form the compiler emits for it.
+    const rules = rulesFor(`.a { background-color: #ff0000; }`, "a");
+
+    expect(rules[0]?.d).toStrictEqual([{ backgroundColor: "#f00" }]);
+  });
+});
+
+describe("::placeholder", () => {
+  test("color maps to placeholderTextColor", () => {
+    const rules = rulesFor(`.a::placeholder { color: #ff0000; }`, "a");
+
+    expect(rules[0]?.d).toStrictEqual([["#f00", ["placeholderTextColor"]]]);
+  });
+
+  test("an unmapped declaration is dropped, not applied to the element", () => {
+    const rules = rulesFor(
+      `.a::placeholder { background-color: #ff0000; }`,
+      "a",
+    );
+
+    expect(rules[0]?.d ?? []).toStrictEqual([]);
+  });
+});

--- a/src/__tests__/compiler/pseudo-elements.test.ts
+++ b/src/__tests__/compiler/pseudo-elements.test.ts
@@ -119,15 +119,100 @@ describe("::selection", () => {
     expect(warnings.values?.["::selection"]).toContain("transitionProperty");
   });
 
-  test("container-name does not make the element a container", () => {
-    // container-name is the one authored declaration that never reaches `d`
+  test.each([
+    "container-name: foo",
+    "container-type: inline-size",
+    "container: foo / inline-size",
+  ])("`%s` does not make the element a container", (declaration) => {
+    // All three reach `c` without passing through `d`, and `c` records only the name, so the
+    // report names the family rather than claiming the user wrote one of the three
     expect(
       compileFor(
-        `.a::selection { background-color: #ff0000; container-name: foo; }`,
+        `.a::selection { background-color: #ff0000; ${declaration}; }`,
       ),
     ).toStrictEqual({
       rules: [{ d: [["#f00", ["selectionColor"]]] }],
-      warnings: { values: { "::selection": ["container-name"] } },
+      warnings: { values: { "::selection": ["container"] } },
+    });
+  });
+
+  test("container-name: none registers no container and reports no drop", () => {
+    // `none` empties `c` rather than leaving it absent, so a report guarded on the field
+    // rather than on its entries would warn about a container that was never registered
+    expect(
+      compileFor(
+        `.a::selection { background-color: #ff0000; container-name: none; }`,
+      ),
+    ).toStrictEqual({
+      rules: [{ d: [["#f00", ["selectionColor"]]] }],
+      warnings: {},
+    });
+  });
+
+  test("every declaration is scoped, not only the first", () => {
+    // A static object and a style-function tuple are separate `d` entries. Every other case
+    // here has one entry, so this is the shape where scoping the first and stopping is
+    // invisible: `background-color` survives either way and only `transform` says otherwise
+    expect(
+      compileFor(
+        `.a::selection { background-color: #ff0000; transform: translateX(1px); }`,
+      ),
+    ).toStrictEqual({
+      rules: [{ d: [["#f00", ["selectionColor"]]] }],
+      warnings: { values: { "::selection": ["transform"] } },
+    });
+  });
+
+  test("a nested property path is reported the way the runtime reads it", () => {
+    // `&` routes a path to the top level instead of nesting it under its first segment, and
+    // `[n]` is an index. Neither is part of the property, and a user cannot act on either
+    expect(
+      compileFor(`.a::selection { text-shadow: 1px 2px 3px red; }`).warnings,
+    ).toStrictEqual({
+      values: {
+        "::selection": [
+          "textShadowColor",
+          "textShadowRadius",
+          "textShadowOffset.width",
+          "textShadowOffset.height",
+        ],
+      },
+    });
+
+    expect(
+      compileFor(`.a::selection { box-shadow: 1px 2px 3px red; }`).warnings,
+    ).toStrictEqual({
+      values: {
+        "::selection": [
+          "boxShadow[0].color",
+          "boxShadow[0].offsetX",
+          "boxShadow[0].offsetY",
+          "boxShadow[0].blurRadius",
+          "boxShadow[0].spreadDistance",
+        ],
+      },
+    });
+  });
+
+  test("a delayed declaration that reads no variable does not set dv", () => {
+    // `em` makes a declaration delayed without making it variable-driven. `dv` is the
+    // variable subscription, so rebuilding it from the delay flag would have the runtime
+    // resolve variables this declaration never reads
+    expect(
+      compileFor(`.a::selection { background-color: hsl(calc(1em) 50% 50%); }`),
+    ).toStrictEqual({
+      rules: [
+        {
+          d: [
+            [
+              [{}, "hsl", [[{}, "calc", [[{}, "em", 1, 1]]], "50%", "50%"]],
+              ["selectionColor"],
+              1,
+            ],
+          ],
+        },
+      ],
+      warnings: {},
     });
   });
 
@@ -182,6 +267,18 @@ describe("::selection", () => {
     );
 
     expect(warnings).toStrictEqual({ values: { "::selection": ["width"] } });
+  });
+
+  test("each pseudo-element in one authored rule reports its own drops", () => {
+    // The counterpart of the dedupe above: it is keyed by pseudo-element, so one authored
+    // rule that expands to two DIFFERENT pseudo-elements reports under both
+    const { warnings } = compileFor(
+      `.a::selection, .b::placeholder { width: 10px; }`,
+    );
+
+    expect(warnings).toStrictEqual({
+      values: { "::selection": ["width"], "::placeholder": ["width"] },
+    });
   });
 
   test("the README example compiles to what the README says", () => {

--- a/src/__tests__/compiler/pseudo-elements.test.ts
+++ b/src/__tests__/compiler/pseudo-elements.test.ts
@@ -1,67 +1,302 @@
 import { compile } from "react-native-css/compiler";
 
 import type { StyleRule } from "../../compiler/compiler.types";
+import {
+  pseudoElementFieldPolicy,
+  scopeRuleToPseudoElement,
+} from "../../compiler/pseudo-elements";
 
-const rulesFor = (css: string, className: string): StyleRule[] => {
-  const result = compile(css).stylesheet();
-  return (result.s?.find(([name]) => name === className)?.[1] ??
-    []) as StyleRule[];
+interface CompiledClass {
+  /** Every field of every rule except `s`, which the selector owns rather than the declarations */
+  rules: Partial<StyleRule>[];
+  warnings: ReturnType<ReturnType<typeof compile>["warnings"]>;
+}
+
+/**
+ * Reads the whole rule, not just `d`. A pseudo-element declaration reaches the element through
+ * any field a declaration can set — `v` carries the --__rn-css-color / --__rn-css-em mirrors
+ * declarations.ts writes beside `color` and `font-size`, `c` registers a named container, and
+ * `a` / `dv` make the host animated or variable-driven
+ */
+const compileFor = (css: string, className = "a"): CompiledClass => {
+  const compiled = compile(css);
+  const rules = (compiled
+    .stylesheet()
+    .s?.find(([name]) => name === className)?.[1] ?? []) as StyleRule[];
+
+  return {
+    rules: rules.map((rule) => {
+      const fields: Partial<StyleRule> = { ...rule };
+      delete fields.s;
+      return fields;
+    }),
+    warnings: compiled.warnings(),
+  };
 };
 
-// The compiler maps one declaration onto a React Native prop and drops the rest;
-// returning an unmapped one applies a ::selection declaration to the real element
 describe("::selection", () => {
-  test("background-color maps to selectionColor", () => {
-    const rules = rulesFor(`.a::selection { background-color: #ff0000; }`, "a");
-
-    expect(rules[0]?.d).toStrictEqual([["#f00", ["selectionColor"]]]);
+  test("background-color maps to selectionColor and sets nothing else", () => {
+    expect(
+      compileFor(`.a::selection { background-color: #ff0000; }`),
+    ).toStrictEqual({
+      rules: [{ d: [["#f00", ["selectionColor"]]] }],
+      warnings: {},
+    });
   });
 
-  test("an unmapped declaration is dropped, not applied to the element", () => {
-    const rules = rulesFor(`.a::selection { width: 10px; }`, "a");
+  test("color paints neither the element nor its subtree", () => {
+    // `color` in ::selection is the selected TEXT colour, which React Native cannot express.
+    // declarations.ts mirrors every `color` into --__rn-css-color, which every descendant reads
+    // as currentColor, so dropping it from `d` alone leaves the subtree painted
+    expect(compileFor(`.a::selection { color: #ff0000; }`)).toStrictEqual({
+      rules: [],
+      warnings: { values: { "::selection": ["color"] } },
+    });
+  });
 
-    expect(rules[0]?.d ?? []).toStrictEqual([]);
+  test("font-size does not become the element's em base", () => {
+    // declarations.ts mirrors every `font-size` into --__rn-css-em, which every em unit on the
+    // element resolves against
+    expect(compileFor(`.a::selection { font-size: 40px; }`)).toStrictEqual({
+      rules: [],
+      warnings: { values: { "::selection": ["fontSize"] } },
+    });
+  });
+
+  test("an unmapped static declaration is dropped", () => {
+    expect(
+      compileFor(`.a::selection { width: 10px; height: 5px; }`),
+    ).toStrictEqual({
+      rules: [],
+      warnings: { values: { "::selection": ["width", "height"] } },
+    });
+  });
+
+  test("an unmapped var() declaration is dropped", () => {
+    // A var() compiles to a style-function tuple rather than the static object every other
+    // "unmapped is dropped" case takes, so it exercises the other branch of the scoping
+    expect(compileFor(`.a::selection { width: var(--x); }`)).toStrictEqual({
+      rules: [],
+      warnings: { values: { "::selection": ["width"] } },
+    });
+  });
+
+  test("an unmapped style-function declaration is dropped", () => {
+    expect(
+      compileFor(`.a::selection { transform: translateX(10px); }`),
+    ).toStrictEqual({
+      rules: [],
+      warnings: { values: { "::selection": ["transform"] } },
+    });
   });
 
   test("an unmapped declaration beside a mapped one is still dropped", () => {
-    const rules = rulesFor(
-      `.a::selection { background-color: #ff0000; width: 10px; }`,
-      "a",
+    expect(
+      compileFor(`.a::selection { background-color: #ff0000; width: 10px; }`),
+    ).toStrictEqual({
+      rules: [{ d: [["#f00", ["selectionColor"]]] }],
+      warnings: { values: { "::selection": ["width"] } },
+    });
+  });
+
+  test("an animation leaves no animated rule behind", () => {
+    // `a` makes the host render through an animated component. With every animation
+    // declaration scoped away there is nothing left for it to animate
+    const { rules, warnings } = compileFor(
+      `.a::selection { animation: spin 1s; }`,
     );
 
-    expect(rules[0]?.d).toStrictEqual([["#f00", ["selectionColor"]]]);
+    expect(rules).toStrictEqual([]);
+    expect(warnings.values?.["::selection"]).toContain("animationName");
   });
 
-  test("color does not paint the element", () => {
-    // color here is the selected TEXT colour, which React Native cannot express;
-    // mapping it to selectionColor would invert its meaning
-    const rules = rulesFor(`.a::selection { color: #ff0000; }`, "a");
+  test("a transition beside a mapped declaration does not animate the element", () => {
+    const { rules, warnings } = compileFor(
+      `.a::selection { background-color: #ff0000; transition: background-color 1s; }`,
+    );
 
-    expect(rules[0]?.d ?? []).toStrictEqual([]);
+    expect(rules).toStrictEqual([{ d: [["#f00", ["selectionColor"]]] }]);
+    expect(warnings.values?.["::selection"]).toContain("transitionProperty");
   });
 
-  test("a plain rule on the same class is untouched", () => {
-    // The control an over-broad fix breaks: only a pseudo-element's own declarations
-    // are scoped away, and a plain rule keeps the static object form
-    const rules = rulesFor(`.a { background-color: #ff0000; }`, "a");
+  test("container-name does not make the element a container", () => {
+    // container-name is the one authored declaration that never reaches `d`
+    expect(
+      compileFor(
+        `.a::selection { background-color: #ff0000; container-name: foo; }`,
+      ),
+    ).toStrictEqual({
+      rules: [{ d: [["#f00", ["selectionColor"]]] }],
+      warnings: { values: { "::selection": ["container-name"] } },
+    });
+  });
 
-    expect(rules[0]?.d).toStrictEqual([{ backgroundColor: "#f00" }]);
+  test("a mapped var() declaration keeps its variable subscription", () => {
+    // The counterpart of the drops above: `dv` is rebuilt, not blanket-cleared, or the
+    // runtime stops resolving the variable the surviving declaration reads
+    expect(
+      compileFor(`.a::selection { background-color: var(--x); }`),
+    ).toStrictEqual({
+      rules: [{ d: [[[{}, "var", "x", 1], ["selectionColor"], 1]], dv: 1 }],
+      warnings: {},
+    });
+  });
+
+  test("the selector's own conditions survive the scoping", () => {
+    expect(
+      compileFor(
+        `@media (min-width: 100px) { .a:hover[data-x]::selection { background-color: #ff0000; } }`,
+      ),
+    ).toStrictEqual({
+      rules: [
+        {
+          d: [["#f00", ["selectionColor"]]],
+          m: [[">=", "width", 100]],
+          p: { h: 1 },
+          aq: [["d", "x"]],
+        },
+      ],
+      warnings: {},
+    });
+  });
+
+  test("a container query survives the scoping", () => {
+    expect(
+      compileFor(
+        `@container (min-width: 100px) { .a::selection { background-color: #ff0000; } }`,
+      ),
+    ).toStrictEqual({
+      rules: [
+        {
+          d: [["#f00", ["selectionColor"]]],
+          cq: [{ m: [">=", "width", 100] }],
+        },
+      ],
+      warnings: {},
+    });
+  });
+
+  test("one authored rule warns once however many selectors it expands to", () => {
+    const { warnings } = compileFor(
+      `.a::selection, .b::selection { width: 10px; }`,
+    );
+
+    expect(warnings).toStrictEqual({ values: { "::selection": ["width"] } });
+  });
+
+  test("the README example compiles to what the README says", () => {
+    expect(
+      compileFor(
+        `.input::selection { background-color: red; color: white; width: 10px; }`,
+        "input",
+      ).warnings,
+    ).toStrictEqual({ values: { "::selection": ["color", "width"] } });
   });
 });
 
 describe("::placeholder", () => {
-  test("color maps to placeholderTextColor", () => {
-    const rules = rulesFor(`.a::placeholder { color: #ff0000; }`, "a");
-
-    expect(rules[0]?.d).toStrictEqual([["#f00", ["placeholderTextColor"]]]);
+  test("color maps to placeholderTextColor and sets nothing else", () => {
+    // The --__rn-css-color mirror leaks here too, even though the declaration IS mapped:
+    // placeholderTextColor is the placeholder's colour, never the element's currentColor
+    expect(compileFor(`.a::placeholder { color: #ff0000; }`)).toStrictEqual({
+      rules: [{ d: [["#f00", ["placeholderTextColor"]]] }],
+      warnings: {},
+    });
   });
 
-  test("an unmapped declaration is dropped, not applied to the element", () => {
-    const rules = rulesFor(
-      `.a::placeholder { background-color: #ff0000; }`,
-      "a",
-    );
+  test("an unmapped declaration is dropped", () => {
+    expect(
+      compileFor(`.a::placeholder { background-color: #ff0000; }`),
+    ).toStrictEqual({
+      rules: [],
+      warnings: { values: { "::placeholder": ["backgroundColor"] } },
+    });
+  });
 
-    expect(rules[0]?.d ?? []).toStrictEqual([]);
+  test("an unmapped var() declaration is dropped", () => {
+    expect(
+      compileFor(`.a::placeholder { background-color: var(--x); }`),
+    ).toStrictEqual({
+      rules: [],
+      warnings: { values: { "::placeholder": ["backgroundColor"] } },
+    });
+  });
+});
+
+describe("rules without a pseudo-element", () => {
+  test("a plain rule on the same class keeps every field", () => {
+    // Control for an over-broad fix: scoping runs per selector, so a rule that reaches the
+    // element directly keeps its static object AND the --__rn-css-color mirror
+    expect(compileFor(`.a { color: #ff0000; }`)).toStrictEqual({
+      rules: [{ d: [{ color: "#f00" }], v: [["__rn-css-color", "#f00"]] }],
+      warnings: {},
+    });
+  });
+
+  test("the unscoped half of a grouped selector is untouched", () => {
+    // Both selectors share one rule object, so scoping the pseudo-element half by mutation
+    // rather than by rebuilding would strip the plain half too
+    const css = `.a::selection, .b { background-color: #ff0000; }`;
+
+    expect(compileFor(css, "a").rules).toStrictEqual([
+      { d: [["#f00", ["selectionColor"]]] },
+    ]);
+    expect(compileFor(css, "b").rules).toStrictEqual([
+      { d: [{ backgroundColor: "#f00" }] },
+    ]);
+  });
+});
+
+describe("field policy", () => {
+  const policyFields = Object.keys(pseudoElementFieldPolicy).filter(
+    (key): key is keyof typeof pseudoElementFieldPolicy =>
+      key in pseudoElementFieldPolicy,
+  );
+
+  test("the policy classifies at least one field of each kind", () => {
+    // Without this, an empty or single-kind policy would make the table below assert nothing
+    for (const kind of ["selector", "rebuilt", "dropped"] as const) {
+      expect(
+        policyFields.filter(
+          (field) => pseudoElementFieldPolicy[field] === kind,
+        ),
+      ).not.toStrictEqual([]);
+    }
+  });
+
+  test("a selector field is carried over and a dropped field never is", () => {
+    // Driven off the policy rather than a hand-written list, so classifying a new StyleRule
+    // field here is what puts it under test
+    const populated: StyleRule = {
+      s: [1, 1],
+      d: [["#f00", "backgroundColor"]],
+      v: [["__rn-css-color", "#f00"]],
+      c: ["c:foo"],
+      dv: 1,
+      a: true,
+      target: "style",
+      m: [[">=", "width", 100]],
+      p: { h: 1 },
+      cq: [{ m: [">=", "width", 100] }],
+      aq: [["d", "x"]],
+    };
+
+    const { rule: scoped } = scopeRuleToPseudoElement(populated, "selection");
+
+    expect(scoped).toBeDefined();
+
+    for (const field of policyFields) {
+      switch (pseudoElementFieldPolicy[field]) {
+        case "selector":
+          expect(scoped).toHaveProperty(field, populated[field]);
+          break;
+        case "dropped":
+          expect(scoped).not.toHaveProperty(field);
+          break;
+        case "rebuilt":
+          // Asserted by the behaviour tests above, which pin what each is rebuilt from
+          break;
+      }
+    }
   });
 });

--- a/src/__tests__/native/pseudo-elements.test.tsx
+++ b/src/__tests__/native/pseudo-elements.test.tsx
@@ -98,6 +98,33 @@ test("::selection { container-name } does not turn the host into a container", (
   );
 });
 
+test("::selection { --custom } does not publish the variable to the subtree", () => {
+  // A custom property is the one authored declaration that lands in `v` rather than `d`, and
+  // `v` is the host's variable scope: carried over, every descendant would read it. The
+  // compiler reports the drop, but nothing carries a compiler warning into the runtime, so
+  // this is the whole of what the native side can observe
+  registerCSS(
+    `
+      .a::selection { background-color: #ff0000; --brand: #00ff00; }
+      .child { background-color: var(--brand); }
+    `,
+    { inlineVariables: false },
+  );
+
+  render(
+    <View>
+      <View className="a">
+        <View testID={testID} className="child" />
+      </View>
+      <View testID={controlTestID} className="child" />
+    </View>,
+  );
+
+  expect(propsWithoutTestID(testID)).toStrictEqual(
+    propsWithoutTestID(controlTestID),
+  );
+});
+
 test("::selection { background-color } still reaches selectionColor", () => {
   registerCSS(`.a::selection { background-color: #ff0000; }`);
 

--- a/src/__tests__/native/pseudo-elements.test.tsx
+++ b/src/__tests__/native/pseudo-elements.test.tsx
@@ -1,0 +1,156 @@
+import { render, screen } from "@testing-library/react-native";
+import { TextInput } from "react-native-css/components/TextInput";
+import { View } from "react-native-css/components/View";
+import { registerCSS, testID } from "react-native-css/jest";
+
+const controlTestID = "control";
+
+/**
+ * Every case here renders the pseudo-element declaration beside a control that carries only
+ * what the platform can express, and asserts the two are indistinguishable. That keeps the
+ * expectation derived rather than a literal copied out of a passing run, and keeps it free of
+ * the platform-specific values a semantic colour or a default rem would otherwise pin
+ */
+const propsWithoutTestID = (id: string): Record<string, unknown> => {
+  const { testID: _testID, ...props } = screen.getByTestId(id).props;
+  return props;
+};
+
+test("::selection { color } does not publish currentcolor to the subtree", () => {
+  // declarations.ts mirrors `color` into --__rn-css-color, which every descendant reads as
+  // currentColor. Scoping only `d` leaves the whole subtree painted the selection colour
+  registerCSS(`
+    .sel::selection { color: #ff0000; }
+    .child { color: currentColor; }
+  `);
+
+  render(
+    <View>
+      <View className="sel">
+        <View testID={testID} className="child" />
+      </View>
+      <View testID={controlTestID} className="child" />
+    </View>,
+  );
+
+  const scoped = propsWithoutTestID(testID);
+
+  expect(scoped).toStrictEqual(propsWithoutTestID(controlTestID));
+  expect(scoped.style).not.toStrictEqual({ color: "#f00" });
+});
+
+test("::selection { font-size } does not become the element's em base", () => {
+  // font-size is mirrored into --__rn-css-em, which every em on the element resolves against
+  registerCSS(`
+    .a::selection { font-size: 40px; }
+    .a { width: 2em; }
+    .control { width: 2em; }
+  `);
+
+  render(
+    <View>
+      <View testID={testID} className="a" />
+      <View testID={controlTestID} className="control" />
+    </View>,
+  );
+
+  expect(propsWithoutTestID(testID)).toStrictEqual(
+    propsWithoutTestID(controlTestID),
+  );
+});
+
+test("::selection { animation } does not render the host as animated", () => {
+  // `a` swaps the host for an animated component. Every animation declaration is scoped away,
+  // so there is nothing left for it to animate
+  registerCSS(`
+    .a::selection { animation: spin 1s; }
+  `);
+
+  render(
+    <View>
+      <View testID={testID} className="a" />
+      <View testID={controlTestID} className="unstyled" />
+    </View>,
+  );
+
+  expect(propsWithoutTestID(testID)).toStrictEqual(
+    propsWithoutTestID(controlTestID),
+  );
+});
+
+test("::selection { container-name } does not turn the host into a container", () => {
+  // `c` registers the host as a named container, which adds onLayout measurement and the
+  // focus/press handlers a container query needs
+  registerCSS(`
+    .a::selection { background-color: #ff0000; container-name: foo; }
+    .control::selection { background-color: #ff0000; }
+  `);
+
+  render(
+    <View>
+      <View testID={testID} className="a" />
+      <View testID={controlTestID} className="control" />
+    </View>,
+  );
+
+  expect(propsWithoutTestID(testID)).toStrictEqual(
+    propsWithoutTestID(controlTestID),
+  );
+});
+
+test("::selection { background-color } still reaches selectionColor", () => {
+  registerCSS(`.a::selection { background-color: #ff0000; }`);
+
+  render(<TextInput testID={testID} className="a" />);
+
+  expect(screen.getByTestId(testID).props).toStrictEqual({
+    children: undefined,
+    selectionColor: "#f00",
+    style: {},
+    testID,
+  });
+});
+
+test("::selection { background-color: var() } still resolves an inherited variable", () => {
+  // The variable lives on an ancestor, so the host only reads it because the scoped rule kept
+  // its `dv` flag. Blanket-clearing the declaration-derived fields would break this
+  registerCSS(`
+    .parent { --x: #ff0000; }
+    .a::selection { background-color: var(--x); }
+  `);
+
+  render(
+    <View className="parent">
+      <TextInput testID={testID} className="a" />
+    </View>,
+  );
+
+  expect(screen.getByTestId(testID).props).toStrictEqual({
+    children: undefined,
+    selectionColor: "#f00",
+    style: {},
+    testID,
+  });
+});
+
+test("::placeholder { color } reaches placeholderTextColor and nothing else", () => {
+  // `color` IS the mapped declaration here, and it still mirrors into --__rn-css-color: the
+  // placeholder's colour must not become the input's currentColor
+  registerCSS(`
+    .a::placeholder { color: #ff0000; }
+    .child { color: currentColor; }
+  `);
+
+  render(
+    <View>
+      <TextInput className="a">
+        <View testID={testID} className="child" />
+      </TextInput>
+      <View testID={controlTestID} className="child" />
+    </View>,
+  );
+
+  expect(propsWithoutTestID(testID)).toStrictEqual(
+    propsWithoutTestID(controlTestID),
+  );
+});

--- a/src/__tests__/native/pseudo-elements.test.tsx
+++ b/src/__tests__/native/pseudo-elements.test.tsx
@@ -133,7 +133,7 @@ test("::selection { background-color: var() } still resolves an inherited variab
   });
 });
 
-test("::placeholder { color } reaches placeholderTextColor and nothing else", () => {
+test("::placeholder { color } does not publish currentcolor to the subtree", () => {
   // `color` IS the mapped declaration here, and it still mirrors into --__rn-css-color: the
   // placeholder's colour must not become the input's currentColor
   registerCSS(`

--- a/src/__tests__/vendor/tailwind/states.test.tsx
+++ b/src/__tests__/vendor/tailwind/states.test.tsx
@@ -80,13 +80,19 @@ test("selection", async () => {
 });
 
 test("selection: an unmappable declaration does not reach the element", async () => {
-  await render(<TextInput testID={testID} className="selection:text-black" />);
+  // selection:text-* is `color` inside ::selection — the selected TEXT colour, which has no
+  // React Native prop. Nothing reaches the element and the compiler says what it dropped
+  const { warnings } = await render(
+    <TextInput testID={testID} className="selection:text-black" />,
+  );
 
-  const component = screen.getByTestId(testID);
-  expect(component.props).toEqual({
+  expect(screen.getByTestId(testID).props).toEqual({
     testID,
     children: undefined,
-    style: {},
+  });
+
+  expect(warnings()).toStrictEqual({
+    values: { "::selection": ["color"] },
   });
 });
 

--- a/src/__tests__/vendor/tailwind/states.test.tsx
+++ b/src/__tests__/vendor/tailwind/states.test.tsx
@@ -65,11 +65,8 @@ test("mixed", async () => {
   expect(component).toHaveStyle({ color: "#fff" });
 });
 
-// `selection:bg-*`, not `selection:text-*`. `selectionColor` is the band
-// painted BEHIND the selected text, which is `background-color` in CSS —
-// `color` there is the selected TEXT's colour, and React Native has no prop
-// for it. Mapping `color` inverted the meaning, so it is dropped now; see the
-// case below.
+// selection:bg-*, not selection:text-*. selectionColor is the band behind the selected
+// text, which is background-color in CSS; color there has no React Native prop
 test("selection", async () => {
   await render(<TextInput testID={testID} className="selection:bg-black" />);
 

--- a/src/__tests__/vendor/tailwind/states.test.tsx
+++ b/src/__tests__/vendor/tailwind/states.test.tsx
@@ -65,13 +65,29 @@ test("mixed", async () => {
   expect(component).toHaveStyle({ color: "#fff" });
 });
 
+// `selection:bg-*`, not `selection:text-*`. `selectionColor` is the band
+// painted BEHIND the selected text, which is `background-color` in CSS —
+// `color` there is the selected TEXT's colour, and React Native has no prop
+// for it. Mapping `color` inverted the meaning, so it is dropped now; see the
+// case below.
 test("selection", async () => {
-  await render(<TextInput testID={testID} className="selection:text-black" />);
+  await render(<TextInput testID={testID} className="selection:bg-black" />);
 
   const component = screen.getByTestId(testID);
   expect(component.props).toEqual({
     testID,
     selectionColor: "#000",
+    children: undefined,
+    style: {},
+  });
+});
+
+test("selection: an unmappable declaration does not reach the element", async () => {
+  await render(<TextInput testID={testID} className="selection:text-black" />);
+
+  const component = screen.getByTestId(testID);
+  expect(component.props).toEqual({
+    testID,
     children: undefined,
     style: {},
   });

--- a/src/compiler/pseudo-elements.ts
+++ b/src/compiler/pseudo-elements.ts
@@ -15,6 +15,13 @@ const pseudoElementProp = {
 
 export type PseudoElement = keyof typeof pseudoElementProp;
 
+/**
+ * The namespace the compiler mints its own custom properties in. `color` and `font-size`
+ * mirror into `--__rn-css-color` / `--__rn-css-em` so the runtime can resolve currentColor and
+ * em, and `direction` into `--__rn-css-direction`
+ */
+export const compilerVariablePrefix = "__rn-css-";
+
 const pseudoElements: PseudoElement[] = Object.keys(pseudoElementProp).filter(
   (key): key is PseudoElement => key in pseudoElementProp,
 );
@@ -82,13 +89,19 @@ export function scopeRuleToPseudoElement(
     scopeDeclaration(declaration, from, to, declarations, dropped);
   }
 
-  // `c` and `v` are the fields an authored declaration reaches without passing through `d`.
-  // Every `c` entry comes from container-name, container-type or the container shorthand, so
-  // the report names the family rather than picking one of the three. `v` is not reported at
-  // all: it holds the compiler's own --__rn-css-* mirrors of a `d` declaration already
-  // reported here alongside any authored custom property, so a `--x` written inside a
-  // pseudo-element is dropped silently. `a` is only ever set beside the `d` entry that set
-  // it, so it is already reported through that entry
+  // `v` and `c` are the fields an authored declaration reaches without passing through `d`.
+  // A `v` entry is reported under the name it was written with, minus the compiler's own
+  // mirrors: each of those sits beside a `d` declaration the loop above already reported, so
+  // naming them would add a variable the user never wrote to every rule that sets a colour or
+  // a font size. Every `c` entry comes from container-name, container-type or the container
+  // shorthand, so the report names the family rather than picking one of the three. `a` is
+  // only ever set beside the `d` entry that set it, so it is already reported through that
+  for (const [name] of rule.v ?? []) {
+    if (!name.startsWith(compilerVariablePrefix)) {
+      dropped.push(`--${name}`);
+    }
+  }
+
   if (rule.c?.length) {
     dropped.push("container");
   }

--- a/src/compiler/pseudo-elements.ts
+++ b/src/compiler/pseudo-elements.ts
@@ -48,7 +48,7 @@ export const pseudoElementFieldPolicy = {
 export interface ScopedRule {
   /** The rule to register, or undefined when no declaration survived the scoping */
   rule: StyleRule | undefined;
-  /** React Native properties the pseudo-element cannot express, in declaration order */
+  /** What the pseudo-element cannot express, in declaration order */
   dropped: string[];
 }
 
@@ -82,12 +82,17 @@ export function scopeRuleToPseudoElement(
     scopeDeclaration(declaration, from, to, declarations, dropped);
   }
 
-  // container-name is the only authored declaration that never reaches `d`. Entries in `v`
-  // are the compiler's own --__rn-css-* mirrors of a `d` declaration already reported here,
-  // and `a` is a flag over animation/transition declarations reported the same way
+  // `c` and `v` are the fields an authored declaration reaches without passing through `d`.
+  // Every `c` entry comes from container-name, container-type or the container shorthand, so
+  // the report names the family rather than picking one of the three. `a` is only ever set
+  // beside the `d` entry that set it, so it is already reported through that entry
   if (rule.c?.length) {
-    dropped.push("container-name");
+    dropped.push("container");
   }
+
+  // `v` is not reported. It holds the compiler's own --__rn-css-* mirrors of a `d`
+  // declaration already reported here, and also any authored custom property, so a `--x`
+  // written inside a pseudo-element is dropped silently
 
   if (!declarations.length) {
     return { rule: undefined, dropped };
@@ -115,8 +120,7 @@ function scopeDeclaration(
   dropped: string[],
 ): void {
   if (Array.isArray(declaration)) {
-    const path = declaration[1];
-    const property = Array.isArray(path) ? path.join(".") : path;
+    const property = toPropertyName(declaration[1]);
 
     if (property !== from) {
       dropped.push(property);
@@ -139,6 +143,29 @@ function scopeDeclaration(
       dropped.push(property);
     }
   }
+}
+
+/**
+ * The React Native property a declaration writes, spelled the way the runtime reads it. A
+ * leading `&` marks a path written at the top level rather than nested under its first
+ * segment, so it is routing rather than part of the name, and a `[n]` segment is an index
+ */
+function toPropertyName(path: string | string[]): string {
+  if (!Array.isArray(path)) {
+    return path;
+  }
+
+  return path.reduce((name, segment, index) => {
+    if (index === 0 && segment === "&") {
+      return name;
+    }
+
+    if (segment.startsWith("[")) {
+      return `${name}${segment}`;
+    }
+
+    return name ? `${name}.${segment}` : segment;
+  }, "");
 }
 
 function usesVariables(declaration: StyleDeclaration): boolean {

--- a/src/compiler/pseudo-elements.ts
+++ b/src/compiler/pseudo-elements.ts
@@ -1,13 +1,26 @@
 import { isStyleFunction } from "../utilities";
 import type { StyleDeclaration, StyleRule } from "./compiler.types";
 
+/**
+ * `::selection` maps `background-color` onto React Native's `selectionColor`.
+ *
+ * `background-color` rather than `color`, because they are opposites here: in
+ * CSS, `color` inside `::selection` is the colour of the selected TEXT, while
+ * React Native's `selectionColor` is the band painted BEHIND it. Mapping
+ * `color` renders a stylesheet asking for white selected text as a white band,
+ * leaving the text it meant to lighten sitting on top of it.
+ */
 export function modifyRuleForSelection(rule: StyleRule): StyleRule | undefined {
   if (!rule.d) {
     return;
   }
 
   rule.d = rule.d.flatMap((declaration): StyleDeclaration[] => {
-    return modifyStyleDeclaration(declaration, "color", "selectionColor");
+    return modifyStyleDeclaration(
+      declaration,
+      "backgroundColor",
+      "selectionColor",
+    );
   });
 
   return rule;
@@ -27,6 +40,16 @@ export function modifyRuleForPlaceholder(
   return rule;
 }
 
+/**
+ * Map the ONE declaration the target platform can express, and DROP the rest.
+ *
+ * Dropping is the whole point. A pseudo-element's declarations are scoped to
+ * the pseudo-element, so returning an unmapped one unchanged applies it to the
+ * real element — `::selection { background-color: blue }` tinted the whole
+ * control rather than the selection. `[]` is the correct answer for something
+ * React Native has no prop for: not applying it is strictly better than
+ * applying it somewhere else.
+ */
 function modifyStyleDeclaration(
   declaration: StyleDeclaration,
   from: string,
@@ -42,13 +65,15 @@ function modifyStyleDeclaration(
       declaration[1] = [to];
       return [declaration];
     }
-  } else if (typeof declaration === "object") {
-    const { color: selectionColor, ...rest } = declaration;
 
-    if (selectionColor) {
-      return [rest, [selectionColor, [to]]] as StyleDeclaration[];
-    }
+    return [];
+  } else if (typeof declaration === "object") {
+    const value = (declaration as Record<string, unknown>)[from];
+
+    return value === undefined
+      ? []
+      : ([[value, [to]]] as unknown as StyleDeclaration[]);
   }
 
-  return [declaration];
+  return [];
 }

--- a/src/compiler/pseudo-elements.ts
+++ b/src/compiler/pseudo-elements.ts
@@ -1,15 +1,8 @@
 import { isStyleFunction } from "../utilities";
 import type { StyleDeclaration, StyleRule } from "./compiler.types";
 
-/**
- * `::selection` maps `background-color` onto React Native's `selectionColor`.
- *
- * `background-color` rather than `color`, because they are opposites here: in
- * CSS, `color` inside `::selection` is the colour of the selected TEXT, while
- * React Native's `selectionColor` is the band painted BEHIND it. Mapping
- * `color` renders a stylesheet asking for white selected text as a white band,
- * leaving the text it meant to lighten sitting on top of it.
- */
+// background-color, not color: in ::selection `color` is the selected TEXT, while
+// selectionColor is the band painted behind it
 export function modifyRuleForSelection(rule: StyleRule): StyleRule | undefined {
   if (!rule.d) {
     return;
@@ -40,16 +33,8 @@ export function modifyRuleForPlaceholder(
   return rule;
 }
 
-/**
- * Map the ONE declaration the target platform can express, and DROP the rest.
- *
- * Dropping is the whole point. A pseudo-element's declarations are scoped to
- * the pseudo-element, so returning an unmapped one unchanged applies it to the
- * real element — `::selection { background-color: blue }` tinted the whole
- * control rather than the selection. `[]` is the correct answer for something
- * React Native has no prop for: not applying it is strictly better than
- * applying it somewhere else.
- */
+// Map the one declaration the platform can express and drop the rest. A pseudo-element's
+// declarations are scoped to it, so returning an unmapped one applies it to the real element
 function modifyStyleDeclaration(
   declaration: StyleDeclaration,
   from: string,

--- a/src/compiler/pseudo-elements.ts
+++ b/src/compiler/pseudo-elements.ts
@@ -1,64 +1,148 @@
-import { isStyleFunction } from "../utilities";
+import { postProcessStyleFunction } from "../utilities";
 import type { StyleDeclaration, StyleRule } from "./compiler.types";
 
-// background-color, not color: in ::selection `color` is the selected TEXT, while
-// selectionColor is the band painted behind it
-export function modifyRuleForSelection(rule: StyleRule): StyleRule | undefined {
-  if (!rule.d) {
-    return;
-  }
+/**
+ * The one declaration each pseudo-element can express on the host component, and the
+ * React Native prop it becomes.
+ *
+ * ::selection maps background-color, not color: in CSS `::selection { color }` is the
+ * selected TEXT, while selectionColor is the band painted behind it
+ */
+const pseudoElementProp = {
+  selection: ["backgroundColor", "selectionColor"],
+  placeholder: ["color", "placeholderTextColor"],
+} as const satisfies Record<string, readonly [string, string]>;
 
-  rule.d = rule.d.flatMap((declaration): StyleDeclaration[] => {
-    return modifyStyleDeclaration(
-      declaration,
-      "backgroundColor",
-      "selectionColor",
-    );
-  });
+export type PseudoElement = keyof typeof pseudoElementProp;
 
-  return rule;
+const pseudoElements: PseudoElement[] = Object.keys(pseudoElementProp).filter(
+  (key): key is PseudoElement => key in pseudoElementProp,
+);
+
+/**
+ * What scoping does with each StyleRule field. A `selector` field describes which elements
+ * the rule matches and is carried over; a `rebuilt` field is recomputed from the declarations
+ * that survive; a `dropped` field belongs to the pseudo-element and never reaches the host.
+ *
+ * `satisfies` makes this total over StyleRule, so a new field fails to compile until it is
+ * classified. That is what stops the next declaration-derived field escaping the
+ * pseudo-element the way `v`, `c`, `dv` and `a` did while only `d` was rewritten
+ */
+export const pseudoElementFieldPolicy = {
+  s: "selector",
+  m: "selector",
+  p: "selector",
+  cq: "selector",
+  aq: "selector",
+  d: "rebuilt",
+  dv: "rebuilt",
+  v: "dropped",
+  c: "dropped",
+  a: "dropped",
+  target: "dropped",
+} as const satisfies Record<
+  keyof StyleRule,
+  "selector" | "rebuilt" | "dropped"
+>;
+
+export interface ScopedRule {
+  /** The rule to register, or undefined when no declaration survived the scoping */
+  rule: StyleRule | undefined;
+  /** React Native properties the pseudo-element cannot express, in declaration order */
+  dropped: string[];
 }
 
-export function modifyRuleForPlaceholder(
+export function getPseudoElement(
+  pseudoElementQuery: string[],
+): PseudoElement | undefined {
+  for (const pseudoElement of pseudoElements) {
+    if (pseudoElementQuery.includes(pseudoElement)) {
+      return pseudoElement;
+    }
+  }
+
+  return undefined;
+}
+
+/**
+ * Rebuild a rule so it carries only what the pseudo-element can express: the one mapped
+ * declaration, under the selector's own conditions. Every other declaration is the
+ * pseudo-element's own and would paint the host element if it were carried over
+ */
+export function scopeRuleToPseudoElement(
   rule: StyleRule,
-): StyleRule | undefined {
-  if (!rule.d) {
-    return;
+  pseudoElement: PseudoElement,
+): ScopedRule {
+  const [from, to] = pseudoElementProp[pseudoElement];
+
+  const declarations: StyleDeclaration[] = [];
+  const dropped: string[] = [];
+
+  for (const declaration of rule.d ?? []) {
+    scopeDeclaration(declaration, from, to, declarations, dropped);
   }
 
-  rule.d = rule.d.flatMap((declaration): StyleDeclaration[] => {
-    return modifyStyleDeclaration(declaration, "color", "placeholderTextColor");
-  });
+  // container-name is the only authored declaration that never reaches `d`. Entries in `v`
+  // are the compiler's own --__rn-css-* mirrors of a `d` declaration already reported here,
+  // and `a` is a flag over animation/transition declarations reported the same way
+  if (rule.c?.length) {
+    dropped.push("container-name");
+  }
 
-  return rule;
+  if (!declarations.length) {
+    return { rule: undefined, dropped };
+  }
+
+  const scoped: StyleRule = { s: rule.s, d: declarations };
+
+  if (rule.m) scoped.m = rule.m;
+  if (rule.p) scoped.p = rule.p;
+  if (rule.cq) scoped.cq = rule.cq;
+  if (rule.aq) scoped.aq = rule.aq;
+
+  if (declarations.some(usesVariables)) {
+    scoped.dv = 1;
+  }
+
+  return { rule: scoped, dropped };
 }
 
-// Map the one declaration the platform can express and drop the rest. A pseudo-element's
-// declarations are scoped to it, so returning an unmapped one applies it to the real element
-function modifyStyleDeclaration(
+function scopeDeclaration(
   declaration: StyleDeclaration,
   from: string,
   to: string,
-): StyleDeclaration[] {
+  declarations: StyleDeclaration[],
+  dropped: string[],
+): void {
   if (Array.isArray(declaration)) {
-    if (isStyleFunction(declaration) && declaration[2] === from) {
-      declaration = [...declaration] as StyleDeclaration;
-      declaration[2] = [to];
-      return [declaration];
-    } else if (declaration[1] === from) {
-      declaration = [...declaration] as StyleDeclaration;
-      declaration[1] = [to];
-      return [declaration];
+    const path = declaration[1];
+    const property = Array.isArray(path) ? path.join(".") : path;
+
+    if (property !== from) {
+      dropped.push(property);
+      return;
     }
 
-    return [];
-  } else if (typeof declaration === "object") {
-    const value = (declaration as Record<string, unknown>)[from];
+    declarations.push(
+      declaration.length === 3
+        ? [declaration[0], [to], declaration[2]]
+        : [declaration[0], [to]],
+    );
 
-    return value === undefined
-      ? []
-      : ([[value, [to]]] as unknown as StyleDeclaration[]);
+    return;
   }
 
-  return [];
+  for (const [property, value] of Object.entries(declaration)) {
+    if (property === from) {
+      declarations.push([value, [to]]);
+    } else {
+      dropped.push(property);
+    }
+  }
+}
+
+function usesVariables(declaration: StyleDeclaration): boolean {
+  return (
+    Array.isArray(declaration) && postProcessStyleFunction(declaration[0])[1]
+  );
 }

--- a/src/compiler/pseudo-elements.ts
+++ b/src/compiler/pseudo-elements.ts
@@ -84,15 +84,14 @@ export function scopeRuleToPseudoElement(
 
   // `c` and `v` are the fields an authored declaration reaches without passing through `d`.
   // Every `c` entry comes from container-name, container-type or the container shorthand, so
-  // the report names the family rather than picking one of the three. `a` is only ever set
-  // beside the `d` entry that set it, so it is already reported through that entry
+  // the report names the family rather than picking one of the three. `v` is not reported at
+  // all: it holds the compiler's own --__rn-css-* mirrors of a `d` declaration already
+  // reported here alongside any authored custom property, so a `--x` written inside a
+  // pseudo-element is dropped silently. `a` is only ever set beside the `d` entry that set
+  // it, so it is already reported through that entry
   if (rule.c?.length) {
     dropped.push("container");
   }
-
-  // `v` is not reported. It holds the compiler's own --__rn-css-* mirrors of a `d`
-  // declaration already reported here, and also any authored custom property, so a `--x`
-  // written inside a pseudo-element is dropped silently
 
   if (!declarations.length) {
     return { rule: undefined, dropped };

--- a/src/compiler/stylesheet.ts
+++ b/src/compiler/stylesheet.ts
@@ -1,7 +1,7 @@
 import type { SelectorList } from "lightningcss";
 
 import {
-  isStyleDescriptorArray,
+  postProcessStyleFunction,
   Specificity,
   specificityCompareFn,
 } from "../utilities";
@@ -22,8 +22,9 @@ import type {
   VariableValue,
 } from "./compiler.types";
 import {
-  modifyRuleForPlaceholder,
-  modifyRuleForSelection,
+  getPseudoElement,
+  scopeRuleToPseudoElement,
+  type PseudoElement,
 } from "./pseudo-elements";
 import { getClassNameSelectors, toRNProperty } from "./selector-builder";
 
@@ -447,15 +448,31 @@ export class StylesheetBuilder {
       this.options,
     );
 
+    const warnedPseudoElements = new Set<PseudoElement>();
+
     for (const selector of normalizedSelectors) {
       // We are going to be apply the current rule to n selectors, so we clone the rule
       let rule: StyleRule | undefined = this.cloneRule(this.rule);
 
       if (selector.type === "className" && selector.pseudoElementQuery) {
-        if (selector.pseudoElementQuery.includes("selection")) {
-          rule = modifyRuleForSelection(rule);
-        } else if (selector.pseudoElementQuery.includes("placeholder")) {
-          rule = modifyRuleForPlaceholder(rule);
+        const pseudoElement = getPseudoElement(selector.pseudoElementQuery);
+
+        if (pseudoElement) {
+          const scoped = scopeRuleToPseudoElement(rule, pseudoElement);
+
+          // A supported property dropped for being in the wrong scope warns like an
+          // unsupported one, keyed by the pseudo-element it was scoped out of. Every
+          // selector scopes the same clone, so one authored rule reports once however
+          // many selectors it expands to
+          if (!warnedPseudoElements.has(pseudoElement)) {
+            warnedPseudoElements.add(pseudoElement);
+
+            for (const property of scoped.dropped) {
+              this.addWarning("style", `::${pseudoElement}`, property);
+            }
+          }
+
+          rule = scoped.rule;
         }
       }
 
@@ -615,40 +632,6 @@ function isStyleFunction(
       typeof value[0] === "object" &&
       Object.keys(value[0]).length === 0,
   );
-}
-
-function postProcessStyleFunction(value: StyleDescriptor): [
-  // Should it be delayed
-  boolean,
-  // Does it use variables
-  boolean,
-] {
-  if (!Array.isArray(value)) {
-    return [false, false];
-  }
-
-  if (isStyleDescriptorArray(value)) {
-    let shouldDelay = false;
-    let usesVariables = false;
-    for (const v of value) {
-      const [delayed, variables] = postProcessStyleFunction(v);
-      shouldDelay ||= delayed;
-      usesVariables ||= variables;
-    }
-
-    return [shouldDelay, usesVariables];
-  }
-
-  let [shouldDelay, usesVariables] = postProcessStyleFunction(value[2]);
-
-  usesVariables ||= value[1] === "var";
-  shouldDelay ||= value[3] === 1 || usesVariables;
-
-  if (shouldDelay) {
-    return [true, usesVariables];
-  }
-
-  return [false, false];
 }
 
 function allEqual(...params: unknown[]) {

--- a/src/utilities/style-descriptor.ts
+++ b/src/utilities/style-descriptor.ts
@@ -22,3 +22,37 @@ export function isStyleFunction(
 
   return false;
 }
+
+export function postProcessStyleFunction(value: StyleDescriptor): [
+  // Should it be delayed
+  boolean,
+  // Does it use variables
+  boolean,
+] {
+  if (!Array.isArray(value)) {
+    return [false, false];
+  }
+
+  if (isStyleDescriptorArray(value)) {
+    let shouldDelay = false;
+    let usesVariables = false;
+    for (const v of value) {
+      const [delayed, variables] = postProcessStyleFunction(v);
+      shouldDelay ||= delayed;
+      usesVariables ||= variables;
+    }
+
+    return [shouldDelay, usesVariables];
+  }
+
+  let [shouldDelay, usesVariables] = postProcessStyleFunction(value[2]);
+
+  usesVariables ||= value[1] === "var";
+  shouldDelay ||= value[3] === 1 || usesVariables;
+
+  if (shouldDelay) {
+    return [true, usesVariables];
+  }
+
+  return [false, false];
+}


### PR DESCRIPTION
> **Breaking.** `::selection { color }` stops painting anything on native. The `BREAKING CHANGE:` footer is on the last commit, so `@release-it/conventional-changelog` reads this branch as a major bump rather than a patch — checked against the preset in `.config/release-it.config.ts`, which reports `{ reason: 'There is 1 BREAKING CHANGE and 0 features', releaseType: 'major' }`.

## Problem

A pseudo-element's declarations are scoped to the pseudo-element. `react-native-css` compiles a `::selection` / `::placeholder` rule by mapping ONE declaration onto a React Native prop and returning every other declaration **unchanged** — so an unmapped one is applied to the real element.

Two consequences, both silent:

1. **`::selection { background-color }` paints the element.** It compiles to exactly what a plain `background-color` on the same class compiles to, so a rule intended to tint a selection tints the whole control.
2. **`::selection { color }` maps to `selectionColor`, which is its opposite.** In CSS, `color` inside `::selection` is the colour of the selected **text**; in React Native `selectionColor` is the **band painted behind it**. A stylesheet asking for white selected text gets a white band, and the text it meant to lighten is unchanged — now sitting on a light band.

`::placeholder` has the same leak on its unmapped side; its `color` → `placeholderTextColor` mapping is correct and is unchanged here.

## Reproduction

No framework, no device, no bundler — the compiler alone.

```js
import { compile } from 'react-native-css/compiler';

const CSS = `
.a::selection   { background-color: rgb(1, 2, 3); }
.b::selection   { color: rgb(4, 5, 6); }
.c::placeholder { background-color: rgb(7, 8, 9); }
.d::placeholder { color: rgb(10, 11, 12); }
.e              { background-color: rgb(1, 2, 3); }
`;

for (const [className, rules] of compile(CSS).stylesheet().s ?? []) {
  console.log(className, JSON.stringify(rules.flatMap((rule) => rule.d ?? [])));
}
```

**Actual, on 3.0.7:**

```
.a    -> [{"backgroundColor":"#010203"}]
.b    -> [{},["#040506",["selectionColor"]]]
.c    -> [{"backgroundColor":"#070809"}]
.d    -> [{},["#0a0b0c",["placeholderTextColor"]]]
.e    -> [{"backgroundColor":"#010203"}]
```

**With this PR:**

```
.a    -> [["#010203",["selectionColor"]]]
.d    -> [["#0a0b0c",["placeholderTextColor"]]]
.e    -> [{"backgroundColor":"#010203"}]
```

`.b` and `.c` do not appear at all — a rule with no surviving declaration is not registered, so the class key is absent from `stylesheet().s` rather than present-and-empty.

Read `.a` against `.e` on 3.0.7. They are **byte-identical output for two selectors that mean different things** — one asks to tint a selection, the other to paint a box, and the compiler cannot tell them apart afterwards. `.b` is the inversion: a request to recolour selected TEXT emerges as the selection BAND.

### What a real app sees

Written together, which is how every web stylesheet styles a selection:

```css
.field::selection {
  background-color: #09090b;
  color: #ffffff;
}
```

3.0.7 renders a near-black background across the whole field plus a white selection band. Neither declaration does what it says, and nothing warns.

## Root cause

`modifyStyleDeclaration` returns unmatched declarations rather than dropping them, on every path — including the mapped one, where `rest` leaks alongside the mapped prop. The second defect is the caller's argument rather than this function's logic: `modifyRuleForSelection` passes `"color"` as the source property, when the property meaning "the selection band" on both platforms is `background-color`.

## The fix — a field policy, not an allowlist

Dropping unmapped declarations closes `d` and leaves every **other** declaration-derived field open. `modifyRuleForSelection` mutated `rule.d` and returned the same rule, so everything else rode along onto the host:

- **`v`** — a `color` mirrors into `--__rn-css-color`, which every descendant reads as `currentColor`, so `.a::selection { color: red }` painted the whole subtree. A `font-size` mirrors into `--__rn-css-em` and became the element's em base.
- **`c`** — `container-name` inside a pseudo-element registered the HOST as a named container.
- **`a`** — a transition or animation left `a: true` on a host with nothing to animate.
- **`dv`** — an unmapped `var()` left `dv: 1` behind.

`modifyRuleForSelection` and `modifyStyleDeclaration` are gone. `scopeRuleToPseudoElement` **rebuilds** the rule from an accumulator instead of mutating it, and every field of `StyleRule` is classified:

```ts
export const pseudoElementFieldPolicy = {
  s: "selector",
  m: "selector",
  p: "selector",
  cq: "selector",
  aq: "selector",
  d: "rebuilt",
  dv: "rebuilt",
  v: "dropped",
  c: "dropped",
  a: "dropped",
  target: "dropped",
} as const satisfies Record<keyof StyleRule, "selector" | "rebuilt" | "dropped">;
```

The `satisfies` over `Record<keyof StyleRule, …>` is the enforcement: adding a field to `StyleRule` fails to compile until it is classified, which is what stops the next declaration-derived field escaping the way `v`, `c`, `dv` and `a` did while only `d` was rewritten.

Dropped declarations are also **reported** — `compile(css).warnings()` gains entries under the synthetic keys `"::selection"` / `"::placeholder"`, deduped per authored rule per pseudo-element. That covers `v`: an authored custom property is the one declaration that lands there rather than in `d`, and it is reported under the name it was written with.

```js
compile(`.a::selection { background-color: red; --brand: blue }`, {
  inlineVariables: false,
}).warnings();
// { values: { "::selection": ["--brand"] } }
```

`v` also carries the compiler's own mirrors — `--__rn-css-color` and `--__rn-css-em` beside `color` and `font-size`, `--__rn-css-direction` beside `direction` — and each of those sits next to a `d` declaration the report already names. Reporting the field wholesale would add a variable the author never wrote to every rule that sets a colour or a font size, so the mirrors are filtered by the namespace they are minted in. The prefix is named once at the filter site and tied to the mint sites by a test that reads the names off a compiled rule rather than restating them, so renaming the namespace at either end goes red.

With `inlineVariables` left on, a custom property declared once is substituted into its uses and its declaration removed before any rule is built — nothing reaches the pseudo-element, so nothing is dropped and nothing is reported. `inlineVariables: false` keeps it, and that is the configuration the README's `VariableContext` section asks for, so it is where the silent drop costs the most.

This makes the drop **representable**, not visible: it lands on `warnings()`, which no real build reads. See the third known limit below.

## Cross-platform: this narrows the gap, it does not widen it

`metro-transformer.ts` returns early for `platform === "web"`, so a browser gets the authored CSS unchanged and `::selection` behaves as CSS specifies. The question is what native does with the same source.

Measured over 18 `::selection` properties, scoring each against what a browser does with a highlight pseudo (CSS Pseudo-Elements L4 §3.2 — only colour and decoration properties are honoured; everything else is ignored, which leaves the host untouched):

|                                              | agrees with the browser |
| -------------------------------------------- | ----------------------- |
| `main`                                       | 1 of 18                 |
| this PR                                      | 15 of 18                |
| properties where this PR agrees **less**     | 0                       |

On `main`, `width` / `height` / `font-size` / `transform` / `opacity` / `border-width` / `margin` / `padding` / `display` / `position` all land on the HOST, `animation` and `transition` set `a: true` on the host, `background-color` paints the host, and `color` publishes `--__rn-css-color` to the whole subtree. A browser does none of that. Measured in isolation, `container-name` and an authored custom property score as agreeing on `main`, but neither is scoped — `modifyRuleForSelection` bails on `if (!rule.d) return`, so a rule whose declarations are ALL unmappable is discarded wholesale. Pair `container-name` with a declaration that does map and it registers the host as a container, which is the 1-of-18 row.

The three still unmatched under this PR are `color`, `text-decoration` and `text-shadow`: a browser paints the selection with them, React Native has no prop for any of them, so nothing happens. That is a change in the KIND of divergence — from mis-styling the host to doing nothing — not an increase in it.

**Separately, and still true: a `selection:text-*` user loses their highlight.** That is a user-facing break, and it is why the last commit carries a `BREAKING CHANGE:` footer. It is not a parity regression — that stylesheet was painting a band where the author asked for text.

## What is breaking

1. **`::selection { color }` is dropped** rather than mapped to `selectionColor`. Anyone relying on 3.0.7's behaviour is relying on an inverted mapping, but they are relying on it. Tailwind's `selection:text-*` stops painting; `selection:bg-*` is the equivalent.
2. **`::selection { background-color }` becomes `selectionColor`** instead of painting the host. This is the one pre-existing expectation the PR rewrites, in `vendor/tailwind/states.test.tsx`.
3. **`v`, `c`, `a` and `target` inside a pseudo-element no longer reach the host.** The real fix, and a live behaviour change for `--__rn-css-color` / `--__rn-css-em` consumers. (`target` is inert — declared on `StyleRule`, set nowhere in `src/compiler`.)
4. **A rule with no surviving declaration is no longer registered.** The class key disappears from `stylesheet().s` — a shape change, not just a value change.
5. **`compile(css).warnings()` gains entries.** Any downstream `toStrictEqual` over `warnings()` for CSS containing a pseudo-element now fails.

If 1 is contentious, 2–5 stand alone: with `background-color` mapped, `color` could keep its current target and merely stop being the only route to the band. Happy to split.

## Known limits

- **`light-dark()` reaches the host on this branch alone; #420 closes it.** `.a::selection { background-color: light-dark(red, blue) }` compiles the light half to `selectionColor` and the dark half into a SECOND rule that the extra-rule path composes after the scoping, so under `prefers-color-scheme: dark` it lands as `{ backgroundColor: "#00f" }` on the host. Same defect, different path — `createRuleFromPartial` replaces `d` wholesale with a partial that never went through the scoping. The fix is to the shared extra-rule path rather than to the pseudo-element scoping, which is why it is a separate PR: #420 opens the extra rule empty and merges it as a rule in its own right, so it goes through the same scoping this one installs. Its §5 is this exact case, `::placeholder` included.
- **The warnings this PR adds are unreachable from a real build.** `metro-transformer.ts` calls only `.stylesheet()`, so `expo start` prints nothing and the only thing an author observes is a declaration with no effect. That is pre-existing — 47 `addWarning("value")` call sites already went nowhere — so I opened it separately as #424 rather than widening this PR.

## Tests

The compiler suite covers every row of the table above, including the `.e` control an over-broad fix would break, and the field-policy test is driven off the policy object rather than a hand-written list, so classifying a new `StyleRule` field is what puts it under test. A native suite renders each case beside a control carrying only what the platform can express and asserts the two are indistinguishable, which keeps the expectations derived rather than copied out of a passing run.

Six tests exist because mutating the source survived the whole suite without them: a nested property path, each of the three container spellings, `container-name: none` (which empties `c` rather than leaving it absent), a rule whose `d` holds more than one entry, a second pseudo-element inside one authored rule, and a delayed declaration that reads no variable and so must not set `dv`. Each was confirmed by re-applying its mutation and watching that test — and only that test — go red.

Two warning strings were wrong and are fixed with the tests above: a dropped `text-shadow` reported `&.textShadowOffset.width`, where `&` is the compiler's own "write at the top level" routing marker rather than part of the name, and a dropped `container-type` reported `container-name`, a property the author never wrote.

The custom-property report is pinned at both ends and on both planes. Compiler: the authored name is reported under `inlineVariables: false` **and** with the optimization left on (declared twice, so inlining keeps it); a property the optimization folds away is **not** reported; a mirror stays silent beside an authored name in the same rule; and one test derives the namespace by reading the `v` names off a compiled rule instead of restating the prefix. Native: an authored `--brand` on a `::selection` rule that **keeps** a mapped declaration — the shape where a carried-over `v` actually reaches the host, which the existing `color` / `font-size` cases cannot reach, since those rules survive with no declaration at all and are dropped whole.

Four mutations, each applied and then reverted, each watched go red for its own reason:

| mutation | red |
| --- | --- |
| remove the report loop | 5 tests, every one naming the absent `--brand` |
| remove the mirror filter | 6 tests, the report naming `--__rn-css-color` / `--__rn-css-em` on rules that merely set a colour |
| rename the namespace constant | the derivation test, listing the three real mints `__rn-css-color`, `__rn-css-direction`, `__rn-css-em` |
| carry `v` over to the host | the native test — the child under `.a` paints `#0f0` from the leaked variable while the control paints nothing |

`README.md` gains a `## Pseudo-elements` section: the mapping table, why it is `background-color` rather than `color`, what an author actually observes when a declaration is dropped, that a custom property is dropped the same way and what `inlineVariables` does to it first, and that all of this is native-only.

