### PR TITLE
fix(native): make colorScheme.set move every reader of the scheme

### DIFF
--- a/src/__tests__/native/color-scheme-appearance-async.test.tsx
+++ b/src/__tests__/native/color-scheme-appearance-async.test.tsx
@@ -1,0 +1,248 @@
+import { useSyncExternalStore } from "react";
+import {
+  Appearance,
+  DeviceEventEmitter,
+  Text,
+  type ColorSchemeName,
+} from "react-native";
+
+import { act, render, screen } from "@testing-library/react-native";
+import { colorScheme } from "react-native-css/runtime";
+
+// The platform applies a `setColorScheme` write LATER, and the react-native
+// pinned here writes its own cache from a read-back taken before that apply
+// lands:
+//
+//   NativeAppearance.setColorScheme(colorScheme ?? 'unspecified');
+//   state.appearance = {colorScheme: toColorScheme(NativeAppearance.getColorScheme())};
+//     — react-native 0.81.4, Libraries/Utilities/Appearance.js
+//
+// Both platforms make that read-back stale. Android's `AppearanceModule`
+// wraps the night-mode switch in `UiThreadUtil.runOnUiThread {}`, which is
+// `mainHandler.postDelayed(runnable, 0)` — always posted, never inline, so
+// `getColorScheme()` still answers from the applied configuration. iOS's
+// `RCTAppearance` `getColorScheme` returns `_currentColorScheme`, assigned at
+// init and inside `appearanceChanged:`, and never by `setColorScheme:`.
+//
+// So the fake below records the request and moves nothing. `applyPendingWrite`
+// is the seam the UI-thread post stands for: an explicit call rather than a
+// timer, so a slow machine cannot change what any test here observes.
+//
+// The sibling `color-scheme-appearance.test.tsx` applies the write inline,
+// which is the shape a caller sees on react-native >= 0.86 — there the cache is
+// the requested value. `color-scheme-appearance-rn-0-86.test.tsx` covers the
+// rest of that version's setter. Between the three, both cache-write rules in
+// the declared peer range (`react-native >= 0.81`) are driven.
+jest.mock("react-native/Libraries/Utilities/NativeAppearance", () => {
+  // What the OS itself reports, and therefore what "unspecified" resolves to
+  const operatingSystemScheme = "light";
+  let appliedScheme: ColorSchemeName = operatingSystemScheme;
+  let pendingRequest: string | undefined;
+
+  const resolveRequest = (request: string): ColorSchemeName =>
+    request === "unspecified"
+      ? operatingSystemScheme
+      : (request as ColorSchemeName);
+
+  return {
+    __esModule: true,
+    default: {
+      // NativeEventEmitter's listener-refcount contract
+      addListener: () => undefined,
+      // The scheme in force, which is not the scheme most recently requested
+      getColorScheme: () => appliedScheme,
+      removeListeners: () => undefined,
+      setColorScheme: (next: string) => {
+        pendingRequest = next;
+      },
+      // The UI-thread post landing. Answers with the scheme now in force, which
+      // is what the platform then echoes on `appearanceChanged`.
+      applyPendingWrite: () => {
+        if (pendingRequest !== undefined) {
+          appliedScheme = resolveRequest(pendingRequest);
+          pendingRequest = undefined;
+        }
+        return appliedScheme;
+      },
+      writeDeviceScheme: (next: ColorSchemeName) => {
+        appliedScheme = next;
+        pendingRequest = undefined;
+      },
+    },
+  };
+});
+
+interface FakeNativeAppearance {
+  applyPendingWrite: () => ColorSchemeName;
+  writeDeviceScheme: (next: ColorSchemeName) => void;
+}
+
+const nativeAppearanceModule: { default: FakeNativeAppearance } =
+  jest.requireMock("react-native/Libraries/Utilities/NativeAppearance");
+const nativeAppearance = nativeAppearanceModule.default;
+
+// The UI-thread post landing, and the `appearanceChanged` event the platform
+// then fires. Appearance.js registers the listener that turns that event into
+// its cache write and its `change` emit.
+const applyAndEchoPlatformWrite = (): void => {
+  const applied = nativeAppearance.applyPendingWrite();
+  DeviceEventEmitter.emit("appearanceChanged", { colorScheme: applied });
+};
+
+// Reset through the platform path, so the fixture does not depend on the setter
+// under test
+const resetToLight = (): void => {
+  nativeAppearance.writeDeviceScheme("light");
+  DeviceEventEmitter.emit("appearanceChanged", { colorScheme: "light" });
+};
+
+// The shape of react-native's own useColorScheme: subscribe through
+// addChangeListener, snapshot through getColorScheme. The real hook cannot be
+// used here — react-native/jest/setup.js replaces it with jest.fn(() => "light")
+// — but it is this store, and so is every other documented way to track the
+// scheme.
+const subscribeToAppearance = (onStoreChange: () => void): (() => void) => {
+  const subscription = Appearance.addChangeListener(onStoreChange);
+  return () => {
+    subscription.remove();
+  };
+};
+
+const readAppearanceColorScheme = (): ColorSchemeName =>
+  Appearance.getColorScheme();
+
+const SubscribedColorScheme = () => {
+  const scheme = useSyncExternalStore(
+    subscribeToAppearance,
+    readAppearanceColorScheme,
+  );
+
+  return <Text testID="subscribed-color-scheme">{scheme ?? "unset"}</Text>;
+};
+
+const readSubscribedColorScheme = (): unknown =>
+  screen.getByTestId("subscribed-color-scheme").props.children;
+
+const recordChangeEvents = (): {
+  heard: ColorSchemeName[];
+  stop: () => void;
+} => {
+  const heard: ColorSchemeName[] = [];
+  const subscription = Appearance.addChangeListener((event) => {
+    heard.push(event.colorScheme);
+  });
+
+  return {
+    heard,
+    stop: () => {
+      subscription.remove();
+    },
+  };
+};
+
+beforeEach(() => {
+  act(() => {
+    resetToLight();
+  });
+});
+
+test("colorScheme.set announces the requested scheme before the platform applies it", () => {
+  const { heard, stop } = recordChangeEvents();
+
+  act(() => {
+    colorScheme.set("dark");
+  });
+
+  // Nothing has been flushed — the platform is still holding the write, so
+  // `Appearance.setColorScheme` has cached a read-back of the OLD scheme. An
+  // announcement derived from that cache reports no change at all; one carrying
+  // the requested value reports the change the caller asked for.
+  expect(heard).toStrictEqual(["dark"]);
+  expect(Appearance.getColorScheme()).toBe("dark");
+  expect(colorScheme.get()).toBe("dark");
+
+  stop();
+});
+
+test("a reader subscribed the way useColorScheme is moves before the platform echo", () => {
+  render(<SubscribedColorScheme />);
+  expect(readSubscribedColorScheme()).toBe("light");
+
+  act(() => {
+    colorScheme.set("dark");
+  });
+
+  // The whole point of the setter: an app that offers a light/dark preference
+  // gets its chrome and its `dark:` utilities on the same scheme in one call,
+  // rather than one of them a UI-thread hop later
+  expect(readSubscribedColorScheme()).toBe("dark");
+});
+
+test("the platform echo that follows repeats the scheme and settles there", () => {
+  const { heard, stop } = recordChangeEvents();
+
+  act(() => {
+    colorScheme.set("dark");
+  });
+  act(() => {
+    applyAndEchoPlatformWrite();
+  });
+
+  // A platform that echoes the write back delivers the same value a second
+  // time. useSyncExternalStore bails on an identical snapshot, and every
+  // reader here holds the scheme that was asked for.
+  expect(heard).toStrictEqual(["dark", "dark"]);
+  expect(Appearance.getColorScheme()).toBe("dark");
+  expect(colorScheme.get()).toBe("dark");
+
+  stop();
+});
+
+test("a redundant set of the scheme the announcement already put in force says nothing", () => {
+  act(() => {
+    colorScheme.set("dark");
+  });
+
+  const { heard, stop } = recordChangeEvents();
+
+  act(() => {
+    colorScheme.set("dark");
+  });
+
+  // The announcement reaches Appearance's own `appearanceChanged` handler, so
+  // the cache it wrote is what the next call reads as the scheme in force. That
+  // is what keeps the second call silent without the setter tracking anything
+  // of its own.
+  expect(heard).toStrictEqual([]);
+
+  stop();
+});
+
+test("set(null) hands the scheme back without announcing a scheme of its own", () => {
+  act(() => {
+    colorScheme.set("dark");
+  });
+
+  const { heard, stop } = recordChangeEvents();
+
+  act(() => {
+    colorScheme.set(null);
+  });
+
+  // There is nothing truthful to announce: the caller named no scheme, and only
+  // the OS knows what handing it back resolves to. `null` is not a scheme any
+  // reader can render — broadcasting it tells useColorScheme() the app has no
+  // scheme at all.
+  expect(heard).toStrictEqual([]);
+
+  act(() => {
+    applyAndEchoPlatformWrite();
+  });
+
+  // The platform's own echo is what delivers the resolved scheme, exactly as it
+  // does for an OS theme change
+  expect(heard).toStrictEqual(["light"]);
+  expect(colorScheme.get()).toBe("light");
+
+  stop();
+});

--- a/src/__tests__/native/color-scheme-appearance-async.test.tsx
+++ b/src/__tests__/native/color-scheme-appearance-async.test.tsx
@@ -28,11 +28,15 @@ import { colorScheme } from "react-native-css/runtime";
 // is the seam the UI-thread post stands for: an explicit call rather than a
 // timer, so a slow machine cannot change what any test here observes.
 //
-// The sibling `color-scheme-appearance.test.tsx` applies the write inline,
-// which is the shape a caller sees on react-native >= 0.86 — there the cache is
-// the requested value. `color-scheme-appearance-rn-0-86.test.tsx` covers the
-// rest of that version's setter. Between the three, both cache-write rules in
-// the declared peer range (`react-native >= 0.81`) are driven.
+// The sibling `color-scheme-appearance.test.tsx` applies the write inline, so
+// the read-back quoted above answers with the requested value — the cache a
+// caller sees from react-native 0.82 on. `color-scheme-appearance-rn-0-86.test.tsx`
+// covers the rest of the current release's setter.
+//
+// Three suites are not three cache-write rules, and the declared peer range
+// (`react-native >= 0.81`) holds three of those:
+// `color-scheme-appearance-cache-rules.test.tsx` is the census, and it is where
+// the 0.82.0-0.84.1 rule between the two ends is driven.
 jest.mock("react-native/Libraries/Utilities/NativeAppearance", () => {
   // What the OS itself reports, and therefore what "unspecified" resolves to
   const operatingSystemScheme = "light";

--- a/src/__tests__/native/color-scheme-appearance-cache-rules.test.tsx
+++ b/src/__tests__/native/color-scheme-appearance-cache-rules.test.tsx
@@ -288,6 +288,19 @@ describe.each(ruleNames)("react-native %s", (rule) => {
     expect(screen.getByTestId(testID).props.style).toStrictEqual(RED);
   });
 
+  test("a follow-the-system request leaves Appearance answering a scheme", () => {
+    // Not this library's channel — this is react-native's own cache, which
+    // `useColorScheme()` and every store built the documented way read.
+    // `colorScheme.set` is the only caller of `Appearance.setColorScheme` here,
+    // so whatever this answers afterwards is what the library left in the app's
+    // cache for everyone else.
+    act(() => {
+      setColorSchemeAcrossBands(handBackFor(rule));
+    });
+
+    expect(["light", "dark"]).toContain(Appearance.getColorScheme());
+  });
+
   test("no platform echo arrives to repair it, because the resolved scheme never changed", () => {
     act(() => {
       setColorSchemeAcrossBands(handBackFor(rule));

--- a/src/__tests__/native/color-scheme-appearance-cache-rules.test.tsx
+++ b/src/__tests__/native/color-scheme-appearance-cache-rules.test.tsx
@@ -1,0 +1,309 @@
+import { Appearance, type ColorSchemeName } from "react-native";
+
+import { act, render, screen } from "@testing-library/react-native";
+import { View } from "react-native-css/components/View";
+import { registerCSS, testID } from "react-native-css/jest";
+import { colorScheme } from "react-native-css/runtime";
+
+// Declared out here because babel's `jest.mock` hoist check reads a parameter
+// name inside an inline constructor type as a variable access
+interface AppearancePreferences {
+  colorScheme: unknown;
+}
+type NativeEventEmitterConstructor = new (nativeModule: unknown) => {
+  addListener: (
+    event: string,
+    listener: (preferences: AppearancePreferences) => void,
+  ) => void;
+};
+type AppearanceEmitterConstructor = new () => {
+  emit: (event: string, payload: AppearancePreferences) => void;
+  addListener: (
+    event: string,
+    listener: (payload: AppearancePreferences) => void,
+  ) => { remove: () => void };
+};
+interface CacheWriteRule {
+  handBack: unknown;
+  setColorScheme: (requested: unknown) => unknown;
+}
+
+// `react-native >= 0.81` is the declared peer range, and across it
+// `Appearance.setColorScheme` writes its cache by three different rules. The
+// mock below is the census of those three, transcribed from
+// Libraries/Utilities/Appearance.js at each boundary, and every test here runs
+// against all three rather than against whichever react-native is installed.
+//
+// The device under all three is the same, and it is the platform both OSes
+// actually implement:
+//
+//   - `NativeAppearance.getColorScheme()` answers the CONFIGURATION IN FORCE,
+//     never a request. Android returns `UiModeUtils.isDarkMode(context)`
+//     resolved to "dark"/"light"; iOS returns `_currentColorScheme`, assigned
+//     at init and in `appearanceChanged:` only. Neither can answer
+//     "unspecified".
+//   - `NativeAppearance.setColorScheme()` does not apply inline. Android wraps
+//     `AppCompatDelegate.setDefaultNightMode` in `UiThreadUtil.runOnUiThread`;
+//     iOS's `setColorScheme:` never assigns `_currentColorScheme`.
+//   - `appearanceChanged` fires only when the RESOLVED scheme changes —
+//     `AppearanceModule.onConfigurationChanged` guards on
+//     `lastEmittedColorScheme != newColorScheme`, and `RCTAppearance` guards on
+//     `![_currentColorScheme isEqualToString:newColorScheme]`. Re-affirming the
+//     scheme already in force emits nothing at all.
+jest.mock("react-native/Libraries/Utilities/Appearance", () => {
+  const NativeEventEmitter = jest.requireActual<{ default: unknown }>(
+    "react-native/Libraries/EventEmitter/NativeEventEmitter",
+  ).default as NativeEventEmitterConstructor;
+  const EventEmitter = jest.requireActual<{ default: unknown }>(
+    "react-native/Libraries/vendor/emitter/EventEmitter",
+  ).default as AppearanceEmitterConstructor;
+
+  let operatingSystemScheme = "dark";
+  let appliedScheme = operatingSystemScheme;
+  let pendingRequest: string | undefined;
+
+  const nativeAppearance = {
+    addListener: () => undefined,
+    // `?ColorSchemeName` in the TurboModule spec — null where there is no
+    // native Appearance module at all
+    getColorScheme: (): string | null => appliedScheme,
+    removeListeners: () => undefined,
+    setColorScheme: (next: string) => {
+      pendingRequest = next;
+    },
+  };
+
+  // The census. Each entry is one release band's `setColorScheme` body, and
+  // nothing else about that release differs on the path these tests walk.
+  const cacheWriteRules = new Map<string, CacheWriteRule>([
+    // NativeAppearance.setColorScheme(colorScheme ?? 'unspecified');
+    // state.appearance = {colorScheme: toColorScheme(NativeAppearance.getColorScheme())};
+    [
+      "<=0.81.5",
+      {
+        // 0.81's Appearance.d.ts declares ColorSchemeName as
+        // 'light' | 'dark' | null | undefined, so null is how a caller on this
+        // band spells "follow the system"
+        handBack: null,
+        setColorScheme: (requested: unknown) => {
+          nativeAppearance.setColorScheme(
+            (requested as string | null) ?? "unspecified",
+          );
+          return nativeAppearance.getColorScheme();
+        },
+      },
+    ],
+    // NativeAppearance.setColorScheme(colorScheme);
+    // state.appearance = {colorScheme};
+    [
+      "0.82.0-0.84.1",
+      {
+        // 0.82's Appearance.d.ts declares ColorSchemeName as
+        // 'light' | 'dark' | 'unspecified' and null leaves the type
+        handBack: "unspecified",
+        setColorScheme: (requested: unknown) => {
+          nativeAppearance.setColorScheme(requested as string);
+          return requested;
+        },
+      },
+    ],
+    // NativeAppearance.setColorScheme(colorScheme);
+    // state.appearance = {colorScheme: colorScheme === 'unspecified'
+    //   ? (NativeAppearance.getColorScheme() ?? colorScheme) : colorScheme};
+    [
+      ">=0.85.3",
+      {
+        handBack: "unspecified",
+        setColorScheme: (requested: unknown) => {
+          nativeAppearance.setColorScheme(requested as string);
+          return requested === "unspecified"
+            ? (nativeAppearance.getColorScheme() ?? requested)
+            : requested;
+        },
+      },
+    ],
+  ]);
+
+  const readRule = (name: string): CacheWriteRule => {
+    const rule = cacheWriteRules.get(name);
+    if (rule === undefined) {
+      throw new Error(`No cache-write rule named ${name}`);
+    }
+    return rule;
+  };
+
+  let activeRule = ">=0.85.3";
+
+  const eventEmitter = new EventEmitter();
+  let appearance: { colorScheme: unknown } | undefined;
+
+  new NativeEventEmitter(nativeAppearance).addListener(
+    "appearanceChanged",
+    (newAppearance) => {
+      appearance = { colorScheme: newAppearance.colorScheme };
+      eventEmitter.emit("change", appearance);
+    },
+  );
+
+  return {
+    addChangeListener: (
+      listener: (payload: { colorScheme: unknown }) => void,
+    ) => eventEmitter.addListener("change", listener),
+    getColorScheme: () => {
+      appearance ??= { colorScheme: nativeAppearance.getColorScheme() };
+      return appearance.colorScheme;
+    },
+    setColorScheme: (requested: unknown) => {
+      appearance = {
+        colorScheme: readRule(activeRule).setColorScheme(requested),
+      };
+    },
+
+    // Test seams — the census, the band selector, and the device
+    cacheWriteRuleNames: () => [...cacheWriteRules.keys()],
+    handBackFor: (rule: string) => readRule(rule).handBack,
+    useCacheWriteRule: (rule: string) => {
+      activeRule = rule;
+    },
+    // The device: the OS preference, the configuration in force, and the JS
+    // cache all put back to `scheme`, without going through the setter under
+    // test
+    resetDeviceTo: (scheme: string) => {
+      operatingSystemScheme = scheme;
+      appliedScheme = scheme;
+      pendingRequest = undefined;
+      appearance = { colorScheme: scheme };
+    },
+    // The UI-thread post landing. Answers with the scheme now in force, and
+    // whether the platform would echo it — it only does when that scheme
+    // CHANGED.
+    applyPendingWrite: () => {
+      const before = appliedScheme;
+      if (pendingRequest !== undefined) {
+        appliedScheme =
+          pendingRequest === "unspecified"
+            ? operatingSystemScheme
+            : pendingRequest;
+        pendingRequest = undefined;
+      }
+      return { applied: appliedScheme, emits: appliedScheme !== before };
+    },
+  };
+});
+
+interface CacheRuleSeams {
+  cacheWriteRuleNames: () => string[];
+  handBackFor: (rule: string) => ColorSchemeName;
+  useCacheWriteRule: (rule: string) => void;
+  resetDeviceTo: (scheme: string) => void;
+  applyPendingWrite: () => { applied: string; emits: boolean };
+}
+
+const {
+  cacheWriteRuleNames,
+  handBackFor,
+  useCacheWriteRule,
+  resetDeviceTo,
+  applyPendingWrite,
+} = jest.requireMock<typeof Appearance & CacheRuleSeams>(
+  "react-native/Libraries/Utilities/Appearance",
+);
+
+// react-native 0.82+ carries "unspecified" where 0.81 carried null, and
+// `colorScheme.set` is typed by whichever one is installed. Under this repo's
+// 0.81 pin the literal is outside the type, so reaching it needs the bridge —
+// the call itself is what a caller on that band writes.
+const setColorSchemeAcrossBands = colorScheme.set as (
+  value: ColorSchemeName,
+) => void;
+
+const emitAppearanceChanged = (scheme: string): void => {
+  const { DeviceEventEmitter } = jest.requireActual<{
+    DeviceEventEmitter: { emit: (event: string, payload: unknown) => void };
+  }>("react-native");
+
+  DeviceEventEmitter.emit("appearanceChanged", { colorScheme: scheme });
+};
+
+// Put the whole world — the OS, the configuration in force, react-native's
+// cache and react-native-css's observable — on `scheme`, through the platform
+// path rather than through the setter under test.
+const settleEverythingOn = (scheme: string): void => {
+  act(() => {
+    resetDeviceTo(scheme);
+    emitAppearanceChanged(scheme);
+  });
+};
+
+const DARK_CONDITIONAL_CSS = `
+.my-class { color: green; }
+
+@media (prefers-color-scheme: light) {
+  .my-class { color: blue; }
+}
+
+@media (prefers-color-scheme: dark) {
+  .my-class { color: red; }
+}`;
+
+const RED = { color: "#f00" } as const;
+
+const ruleNames = cacheWriteRuleNames();
+
+test("the cache-write census is not empty", () => {
+  // The vacuity guard: an empty census would make every describe.each below
+  // generate no cases and leave this file silently green
+  expect(ruleNames.length).toBeGreaterThan(0);
+});
+
+describe.each(ruleNames)("react-native %s", (rule) => {
+  beforeEach(() => {
+    useCacheWriteRule(rule);
+    settleEverythingOn("dark");
+  });
+
+  test("the fixture starts with every layer on the dark system scheme", () => {
+    expect(Appearance.getColorScheme()).toBe("dark");
+    expect(colorScheme.get()).toBe("dark");
+  });
+
+  test("a follow-the-system request leaves colorScheme.get() on the OS scheme", () => {
+    act(() => {
+      setColorSchemeAcrossBands(handBackFor(rule));
+    });
+
+    // The user asked to follow the system and the system is dark. What the
+    // caller wrote is identical on every band; what they read back must be too
+    expect(colorScheme.get()).toBe("dark");
+  });
+
+  test("a follow-the-system request leaves the class layer on the OS scheme", () => {
+    registerCSS(DARK_CONDITIONAL_CSS);
+    render(<View testID={testID} className="my-class" />);
+
+    act(() => {
+      setColorSchemeAcrossBands(handBackFor(rule));
+    });
+
+    expect(screen.getByTestId(testID).props.style).toStrictEqual(RED);
+  });
+
+  test("no platform echo arrives to repair it, because the resolved scheme never changed", () => {
+    act(() => {
+      setColorSchemeAcrossBands(handBackFor(rule));
+    });
+
+    act(() => {
+      const { applied, emits } = applyPendingWrite();
+
+      // Re-affirming the scheme already in force resolves to the same scheme,
+      // so neither AppearanceModule nor RCTAppearance emits. Nothing arrives to
+      // overwrite a cache left holding a non-scheme; on Android the next event
+      // is the user toggling their system theme.
+      expect(applied).toBe("dark");
+      expect(emits).toBe(false);
+    });
+
+    expect(colorScheme.get()).toBe("dark");
+  });
+});

--- a/src/__tests__/native/color-scheme-appearance-rn-0-86.test.tsx
+++ b/src/__tests__/native/color-scheme-appearance-rn-0-86.test.tsx
@@ -276,3 +276,27 @@ test("a redundant set of the scheme already in force announces nothing", () => {
 
   stop();
 });
+
+test("set('unspecified') resolves to a renderable scheme before the platform echoes", () => {
+  act(() => {
+    colorScheme.set("dark");
+    applyAndEchoPlatformWrite();
+  });
+
+  act(() => {
+    setColorScheme086("unspecified");
+  });
+
+  // No echo yet. The test above steps straight past this window, which is why
+  // nothing caught the leak: "unspecified" is a REQUEST to follow the system,
+  // never a scheme, and the resolution chain totalizes on NULLISHNESS, so the
+  // literal passes through every `??` untouched.
+  //
+  // A reader handed it matches neither `prefers-color-scheme: dark` nor
+  // `: light`, so every scheme-conditional class goes dead rather than falling
+  // back — the app asks to follow a dark system and loses its dark styling.
+  // On Android nothing repairs it until the user toggles the system theme,
+  // because AppearanceModule only emits when the RESOLVED scheme changes.
+  expect(colorScheme.get()).not.toBe("unspecified");
+  expect(["dark", "light"]).toContain(colorScheme.get());
+});

--- a/src/__tests__/native/color-scheme-appearance-rn-0-86.test.tsx
+++ b/src/__tests__/native/color-scheme-appearance-rn-0-86.test.tsx
@@ -17,20 +17,25 @@ import { colorScheme } from "react-native-css/runtime";
 //   };
 //     — react-native 0.86.0, Libraries/Utilities/Appearance.js
 //
-// The 0.81.4 pinned in this repo reads the cache back on every path, and
-// `toColorScheme` is gone by 0.86 along with its invariant. `ColorSchemeName`
-// moved too: 0.81 declares 'light' | 'dark' | null | undefined, 0.86 declares
-// 'light' | 'dark' | 'unspecified', so on the current release "unspecified" is
-// the type-legal way to hand the scheme back and `null` is not in the type at
-// all.
+// The 0.81.4 pinned in this repo reads the cache back on every path. The rest
+// of the distance to the shape above is 0.82.0, in one release rather than
+// spread across the range: `toColorScheme` and its invariant were deleted, and
+// `Libraries/Utilities/Appearance.d.ts` re-declared `ColorSchemeName` from
+// 'light' | 'dark' | null | undefined to 'light' | 'dark' | 'unspecified'. So
+// from 0.82 on, "unspecified" is the type-legal way to hand the scheme back and
+// `null` is not in the type at all.
 //
-// `react-native >= 0.81` is the declared peer range, so both are shipping
-// behaviour and no single installed react-native can express both. The two
-// sibling suites drive the installed module; this one stands in for the version
-// that cannot be installed beside it, transcribing the four functions of
-// Appearance.js and nothing else — the `appearanceChanged` registration is
-// still react-native's own `NativeEventEmitter`, so what reaches this cache is
-// what reaches the real one.
+// `react-native >= 0.81` is the declared peer range, so the 0.81 shape and the
+// 0.86 shape are both shipping and no single installed react-native can express
+// both. The two sibling suites drive the installed module; this one stands in
+// for the current release, transcribing the four functions of Appearance.js and
+// nothing else — the `appearanceChanged` registration is still react-native's
+// own `NativeEventEmitter`, so what reaches this cache is what reaches the real
+// one.
+//
+// Neither shape is the whole range. `color-scheme-appearance-cache-rules.test.tsx`
+// carries the census of all three cache-write rules, including the
+// 0.82.0-0.84.1 one that neither this file nor the installed module can reach.
 
 // Declared out here because babel's `jest.mock` hoist check reads a parameter
 // name inside an inline constructor type as a variable access

--- a/src/__tests__/native/color-scheme-appearance-rn-0-86.test.tsx
+++ b/src/__tests__/native/color-scheme-appearance-rn-0-86.test.tsx
@@ -3,9 +3,10 @@ import { Appearance, type ColorSchemeName } from "react-native";
 import { act } from "@testing-library/react-native";
 import { colorScheme } from "react-native-css/runtime";
 
-// react-native 0.86 rewrote the one expression the announcement used to read.
-// `setColorScheme` writes the cache from the REQUESTED value, and the native
-// read-back survives only for the literal "unspecified":
+// react-native 0.82 rewrote the one expression the announcement used to read:
+// `setColorScheme` stopped reading the cache back and wrote the REQUESTED
+// value instead. By 0.85.3 a read-back had returned for the literal
+// "unspecified" alone — the shape quoted here, and the one 0.86.0 ships:
 //
 //   NativeAppearance.setColorScheme(colorScheme);
 //   state.appearance = {

--- a/src/__tests__/native/color-scheme-appearance-rn-0-86.test.tsx
+++ b/src/__tests__/native/color-scheme-appearance-rn-0-86.test.tsx
@@ -1,0 +1,278 @@
+import { Appearance, type ColorSchemeName } from "react-native";
+
+import { act } from "@testing-library/react-native";
+import { colorScheme } from "react-native-css/runtime";
+
+// react-native 0.86 rewrote the one expression the announcement used to read.
+// `setColorScheme` writes the cache from the REQUESTED value, and the native
+// read-back survives only for the literal "unspecified":
+//
+//   NativeAppearance.setColorScheme(colorScheme);
+//   state.appearance = {
+//     colorScheme:
+//       colorScheme === 'unspecified'
+//         ? (NativeAppearance.getColorScheme() ?? colorScheme)
+//         : colorScheme,
+//   };
+//     — react-native 0.86.0, Libraries/Utilities/Appearance.js
+//
+// The 0.81.4 pinned in this repo reads the cache back on every path, and
+// `toColorScheme` is gone by 0.86 along with its invariant. `ColorSchemeName`
+// moved too: 0.81 declares 'light' | 'dark' | null | undefined, 0.86 declares
+// 'light' | 'dark' | 'unspecified', so on the current release "unspecified" is
+// the type-legal way to hand the scheme back and `null` is not in the type at
+// all.
+//
+// `react-native >= 0.81` is the declared peer range, so both are shipping
+// behaviour and no single installed react-native can express both. The two
+// sibling suites drive the installed module; this one stands in for the version
+// that cannot be installed beside it, transcribing the four functions of
+// Appearance.js and nothing else — the `appearanceChanged` registration is
+// still react-native's own `NativeEventEmitter`, so what reaches this cache is
+// what reaches the real one.
+
+// Declared out here because babel's `jest.mock` hoist check reads a parameter
+// name inside an inline constructor type as a variable access
+interface AppearancePreferences {
+  colorScheme: ColorSchemeName;
+}
+type NativeEventEmitterConstructor = new (nativeModule: unknown) => {
+  addListener: (
+    event: string,
+    listener: (preferences: AppearancePreferences) => void,
+  ) => void;
+};
+type AppearanceEmitterConstructor = new () => {
+  emit: (event: string, payload: AppearancePreferences) => void;
+  addListener: (
+    event: string,
+    listener: (payload: AppearancePreferences) => void,
+  ) => { remove: () => void };
+};
+
+jest.mock("react-native/Libraries/Utilities/Appearance", () => {
+  const NativeEventEmitter = jest.requireActual<{ default: unknown }>(
+    "react-native/Libraries/EventEmitter/NativeEventEmitter",
+  ).default as NativeEventEmitterConstructor;
+  const EventEmitter = jest.requireActual<{ default: unknown }>(
+    "react-native/Libraries/vendor/emitter/EventEmitter",
+  ).default as AppearanceEmitterConstructor;
+
+  // The platform applies the write on a later turn and answers from the
+  // configuration in force until it does — Android posts the night-mode switch
+  // to the UI thread, iOS never assigns `_currentColorScheme` in the setter.
+  const operatingSystemScheme: ColorSchemeName = "light";
+  let appliedScheme: ColorSchemeName = operatingSystemScheme;
+  let pendingRequest: string | undefined;
+
+  const nativeAppearance = {
+    addListener: () => undefined,
+    getColorScheme: () => appliedScheme,
+    removeListeners: () => undefined,
+    setColorScheme: (next: string) => {
+      pendingRequest = next;
+    },
+  };
+
+  const eventEmitter = new EventEmitter();
+  let appearance: AppearancePreferences | undefined;
+
+  new NativeEventEmitter(nativeAppearance).addListener(
+    "appearanceChanged",
+    (newAppearance) => {
+      appearance = { colorScheme: newAppearance.colorScheme };
+      eventEmitter.emit("change", appearance);
+    },
+  );
+
+  return {
+    addChangeListener: (listener: (payload: AppearancePreferences) => void) =>
+      eventEmitter.addListener("change", listener),
+    getColorScheme: () => {
+      appearance ??= { colorScheme: nativeAppearance.getColorScheme() };
+      return appearance.colorScheme;
+    },
+    setColorScheme: (requested: ColorSchemeName) => {
+      nativeAppearance.setColorScheme(requested as string);
+      appearance = {
+        colorScheme:
+          (requested as string) === "unspecified"
+            ? (nativeAppearance.getColorScheme() ?? requested)
+            : requested,
+      };
+    },
+    // The UI-thread post landing. Answers with the scheme now in force, which is
+    // what the platform then echoes on `appearanceChanged`.
+    applyPendingWrite: () => {
+      if (pendingRequest !== undefined) {
+        appliedScheme =
+          pendingRequest === "unspecified"
+            ? operatingSystemScheme
+            : (pendingRequest as ColorSchemeName);
+        pendingRequest = undefined;
+      }
+      return appliedScheme;
+    },
+    writeDeviceScheme: (next: ColorSchemeName) => {
+      appliedScheme = next;
+      pendingRequest = undefined;
+    },
+  };
+});
+
+interface Rn086Appearance {
+  applyPendingWrite: () => ColorSchemeName;
+  writeDeviceScheme: (next: ColorSchemeName) => void;
+}
+
+const { applyPendingWrite, writeDeviceScheme } = jest.requireMock<
+  typeof Appearance & Rn086Appearance
+>("react-native/Libraries/Utilities/Appearance");
+
+// react-native 0.86's ColorSchemeName carries "unspecified" where 0.81 carried
+// null, and `colorScheme.set` is typed by whichever one is installed. Under this
+// repo's 0.81 pin the literal is outside the type, so reaching it needs the
+// bridge — the call itself is what a caller on the current release writes.
+const setColorScheme086 = colorScheme.set as (value: string) => void;
+
+const emitAppearanceChanged = (scheme: ColorSchemeName): void => {
+  // Where the platform's own event arrives — the emitter NativeEventEmitter
+  // registered the handler on
+  const { DeviceEventEmitter } = jest.requireActual<{
+    DeviceEventEmitter: { emit: (event: string, payload: unknown) => void };
+  }>("react-native");
+
+  DeviceEventEmitter.emit("appearanceChanged", { colorScheme: scheme });
+};
+
+const applyAndEchoPlatformWrite = (): void => {
+  emitAppearanceChanged(applyPendingWrite());
+};
+
+const recordChangeEvents = (): {
+  heard: ColorSchemeName[];
+  stop: () => void;
+} => {
+  const heard: ColorSchemeName[] = [];
+  const subscription = Appearance.addChangeListener((event) => {
+    heard.push(event.colorScheme);
+  });
+
+  return {
+    heard,
+    stop: () => {
+      subscription.remove();
+    },
+  };
+};
+
+beforeEach(() => {
+  // Reset through the platform path, so the fixture does not depend on the
+  // setter under test
+  act(() => {
+    writeDeviceScheme("light");
+    emitAppearanceChanged("light");
+  });
+});
+
+test("colorScheme.set announces the requested scheme once", () => {
+  const { heard, stop } = recordChangeEvents();
+
+  act(() => {
+    colorScheme.set("dark");
+  });
+
+  expect(heard).toStrictEqual(["dark"]);
+  expect(Appearance.getColorScheme()).toBe("dark");
+  expect(colorScheme.get()).toBe("dark");
+
+  act(() => {
+    applyAndEchoPlatformWrite();
+  });
+
+  // A platform that echoes the write back delivers the same value a second
+  // time, and every reader settles on the scheme that was asked for
+  expect(heard).toStrictEqual(["dark", "dark"]);
+  expect(Appearance.getColorScheme()).toBe("dark");
+
+  stop();
+});
+
+test("set(null) hands the scheme back without broadcasting a null scheme", () => {
+  act(() => {
+    colorScheme.set("dark");
+    applyAndEchoPlatformWrite();
+  });
+
+  const { heard, stop } = recordChangeEvents();
+
+  act(() => {
+    colorScheme.set(null);
+  });
+
+  // 0.86 caches the requested value as-is, so the cache goes null on this call
+  // and an announcement derived from it broadcasts `{colorScheme: null}` to
+  // every subscriber — telling useColorScheme() the app has no scheme. The
+  // caller named no scheme, so there is nothing truthful to announce.
+  expect(heard).toStrictEqual([]);
+
+  // What the platform makes of a null request is not modelled: 0.86 forwards it
+  // to the native module unchanged, where the spec's ColorSchemeName is
+  // 'light' | 'dark' | 'unspecified' and null is not a member. The next test
+  // covers the spelling 0.86's own type asks for. What matters here is that the
+  // channel is intact — an OS change still reaches every reader.
+  act(() => {
+    writeDeviceScheme("light");
+    emitAppearanceChanged("light");
+  });
+
+  expect(heard).toStrictEqual(["light"]);
+  expect(colorScheme.get()).toBe("light");
+
+  stop();
+});
+
+test("set('unspecified') hands the scheme back without broadcasting the literal", () => {
+  act(() => {
+    colorScheme.set("dark");
+    applyAndEchoPlatformWrite();
+  });
+
+  const { heard, stop } = recordChangeEvents();
+
+  act(() => {
+    setColorScheme086("unspecified");
+  });
+
+  // The same hand-back, spelled the way 0.86's type requires. "unspecified" is
+  // a request, never a scheme: broadcasting it puts a value in the cache that
+  // no `prefers-color-scheme` reader can match, and on 0.81 it trips
+  // `toColorScheme`'s invariant outright.
+  expect(heard).toStrictEqual([]);
+
+  act(() => {
+    applyAndEchoPlatformWrite();
+  });
+
+  expect(heard).toStrictEqual(["light"]);
+  expect(colorScheme.get()).toBe("light");
+
+  stop();
+});
+
+test("a redundant set of the scheme already in force announces nothing", () => {
+  act(() => {
+    colorScheme.set("dark");
+    applyAndEchoPlatformWrite();
+  });
+
+  const { heard, stop } = recordChangeEvents();
+
+  act(() => {
+    colorScheme.set("dark");
+  });
+
+  expect(heard).toStrictEqual([]);
+
+  stop();
+});

--- a/src/__tests__/native/color-scheme-appearance.test.tsx
+++ b/src/__tests__/native/color-scheme-appearance.test.tsx
@@ -1,68 +1,94 @@
-import { Appearance, type ColorSchemeName } from "react-native";
+import { useSyncExternalStore } from "react";
+import {
+  Appearance,
+  DeviceEventEmitter,
+  Text,
+  type ColorSchemeName,
+} from "react-native";
 
 import { act, render, screen } from "@testing-library/react-native";
 import { View } from "react-native-css/components/View";
 import { registerCSS, testID } from "react-native-css/jest";
 import { colorScheme } from "react-native-css/runtime";
 
-// A stand-in for Appearance, matching react-native/Libraries/Utilities/Appearance.js:
-// getColorScheme reads a process-lifetime cache and setColorScheme writes it. Under the
-// jest preset the real module is the absent-native branch, where every read is null and
-// setColorScheme is a no-op, so it cannot express this.
+// Under the jest preset TurboModuleRegistry.get("Appearance") is null, so
+// react-native's Appearance takes its absent-native branch: every read is null,
+// setColorScheme is a no-op and no `appearanceChanged` listener is registered.
 //
-// It cannot reach useColorScheme, and no fake can: react-native/jest/setup.js:122 replaces
-// that hook with jest.fn(() => "light"), and the real one imports { getColorScheme } from
-// ./Appearance directly rather than through the namespace object replaced below. So the
-// claim that RN's own readers now agree is argued from Appearance's semantics, not tested.
-type ChangeListener = (event: { colorScheme: ColorSchemeName }) => void;
+// Faking that ONE module — rather than replacing Appearance itself — leaves the
+// real Libraries/Utilities/Appearance.js running, so the cache, the change
+// event, the `unspecified` coercion and their ordering are react-native's own
+// rather than a transcription of them. That matters here specifically: the
+// behaviour under test is which of Appearance's two write paths emits.
+jest.mock("react-native/Libraries/Utilities/NativeAppearance", () => {
+  let deviceScheme: ColorSchemeName = "light";
+  const setColorSchemeCalls: string[] = [];
 
-interface FakeAppearance {
-  getColorScheme: () => ColorSchemeName;
-  setColorScheme: (scheme: ColorSchemeName) => void;
-  addChangeListener: (listener: ChangeListener) => { remove: () => void };
-  emitOperatingSystemChange: (scheme: ColorSchemeName) => void;
-  readSetCalls: () => ColorSchemeName[];
-}
-
-jest.mock("react-native", () => {
-  const ReactNative = jest.requireActual("react-native");
-
-  let cachedScheme: ColorSchemeName = "light";
-  const setCalls: ColorSchemeName[] = [];
-  const listeners = new Set<ChangeListener>();
-
-  const fakeAppearance: FakeAppearance = {
-    getColorScheme: () => cachedScheme,
-    setColorScheme: (scheme) => {
-      setCalls.push(scheme);
-      cachedScheme = scheme;
+  return {
+    __esModule: true,
+    default: {
+      // NativeEventEmitter's listener-refcount contract
+      addListener: () => undefined,
+      getColorScheme: () => deviceScheme,
+      readSetColorSchemeCalls: () => [...setColorSchemeCalls],
+      removeListeners: () => undefined,
+      setColorScheme: (next: string) => {
+        setColorSchemeCalls.push(next);
+        // The platform resolves "unspecified" to whatever it is following. With
+        // no OS behind this fake, that is nothing.
+        deviceScheme =
+          next === "unspecified" ? null : (next as ColorSchemeName);
+      },
+      writeDeviceScheme: (next: ColorSchemeName) => {
+        deviceScheme = next;
+      },
     },
-    addChangeListener: (listener) => {
-      listeners.add(listener);
-      return {
-        remove: () => {
-          listeners.delete(listener);
-        },
-      };
-    },
-    emitOperatingSystemChange: (scheme) => {
-      cachedScheme = scheme;
-      for (const listener of listeners) {
-        listener({ colorScheme: scheme });
-      }
-    },
-    readSetCalls: () => setCalls,
   };
-
-  Object.defineProperty(ReactNative, "Appearance", {
-    configurable: true,
-    get: () => fakeAppearance,
-  });
-
-  return ReactNative as unknown;
 });
 
-const appearance = Appearance as unknown as FakeAppearance;
+interface FakeNativeAppearance {
+  readSetColorSchemeCalls: () => string[];
+  writeDeviceScheme: (next: ColorSchemeName) => void;
+}
+
+const nativeAppearanceModule: { default: FakeNativeAppearance } =
+  jest.requireMock("react-native/Libraries/Utilities/NativeAppearance");
+const nativeAppearance = nativeAppearanceModule.default;
+
+// What an OS theme change is: the native module's own state moves, then it
+// emits `appearanceChanged`. Appearance.js registers the listener that turns
+// that event into its cache write and its `change` emit.
+const emitOperatingSystemChange = (scheme: ColorSchemeName): void => {
+  nativeAppearance.writeDeviceScheme(scheme);
+  DeviceEventEmitter.emit("appearanceChanged", { colorScheme: scheme });
+};
+
+// The shape of react-native's own useColorScheme: subscribe through
+// addChangeListener, snapshot through getColorScheme. The real hook cannot be
+// used here — react-native/jest/setup.js replaces it with jest.fn(() => "light")
+// — but it is this store, and so is every other documented way to track the
+// scheme.
+const subscribeToAppearance = (onStoreChange: () => void): (() => void) => {
+  const subscription = Appearance.addChangeListener(onStoreChange);
+  return () => {
+    subscription.remove();
+  };
+};
+
+const readAppearanceColorScheme = (): ColorSchemeName =>
+  Appearance.getColorScheme();
+
+const SubscribedColorScheme = () => {
+  const scheme = useSyncExternalStore(
+    subscribeToAppearance,
+    readAppearanceColorScheme,
+  );
+
+  return <Text testID="subscribed-color-scheme">{scheme ?? "unset"}</Text>;
+};
+
+const readSubscribedColorScheme = (): unknown =>
+  screen.getByTestId("subscribed-color-scheme").props.children;
 
 // Three-way, so "matched neither branch" is distinguishable from "matched light"
 const TRI_STATE_CSS = `
@@ -81,7 +107,11 @@ const BLUE = { color: "#00f" } as const;
 const RED = { color: "#f00" } as const;
 
 beforeEach(() => {
-  appearance.setColorScheme("light");
+  // Reset through the platform path, so the fixture does not depend on the
+  // setter under test
+  act(() => {
+    emitOperatingSystemChange("light");
+  });
 });
 
 test("colorScheme.set writes through to Appearance, so both readers agree", () => {
@@ -93,15 +123,95 @@ test("colorScheme.set writes through to Appearance, so both readers agree", () =
 
   // The argument, not just the resulting cache: without the write-through the cache
   // would still read "light" here, but so would a fix that passed the wrong value
-  expect(appearance.readSetCalls().at(-1)).toBe("dark");
-  expect(appearance.getColorScheme()).toBe("dark");
+  expect(nativeAppearance.readSetColorSchemeCalls().at(-1)).toBe("dark");
+  expect(Appearance.getColorScheme()).toBe("dark");
 
   act(() => {
     colorScheme.set("light");
   });
 
-  expect(appearance.readSetCalls().at(-1)).toBe("light");
-  expect(appearance.getColorScheme()).toBe("light");
+  expect(nativeAppearance.readSetColorSchemeCalls().at(-1)).toBe("light");
+  expect(Appearance.getColorScheme()).toBe("light");
+});
+
+test("colorScheme.set notifies Appearance's subscribers, not just its cache", () => {
+  // The write-through moves getColorScheme() and nothing else: RN's
+  // setColorScheme assigns the cache and calls the native module, and the only
+  // eventEmitter.emit("change") in Appearance.js is inside the native
+  // `appearanceChanged` handler. So a write the platform does not echo back
+  // moves the direct read and tells no subscriber.
+  const heard: ColorSchemeName[] = [];
+  const subscription = Appearance.addChangeListener((event) => {
+    heard.push(event.colorScheme);
+  });
+
+  act(() => {
+    colorScheme.set("dark");
+  });
+
+  expect(Appearance.getColorScheme()).toBe("dark");
+  expect(heard).toStrictEqual(["dark"]);
+
+  act(() => {
+    colorScheme.set("light");
+  });
+
+  expect(heard).toStrictEqual(["dark", "light"]);
+
+  subscription.remove();
+});
+
+test("a colorScheme.set to the scheme already in force announces nothing", () => {
+  // The announcement reports a change and never invents one. Same guard that
+  // keeps it silent where there is no native Appearance module to move, and
+  // the same equality the observable's own set applies
+  const heard: ColorSchemeName[] = [];
+  const subscription = Appearance.addChangeListener((event) => {
+    heard.push(event.colorScheme);
+  });
+
+  act(() => {
+    colorScheme.set("light");
+  });
+
+  expect(Appearance.getColorScheme()).toBe("light");
+  expect(heard).toStrictEqual([]);
+
+  subscription.remove();
+});
+
+test("a reader subscribed the way useColorScheme is moves with colorScheme.set", () => {
+  render(<SubscribedColorScheme />);
+  expect(readSubscribedColorScheme()).toBe("light");
+
+  act(() => {
+    colorScheme.set("dark");
+  });
+
+  // Without the notification this reads "light" while Appearance.getColorScheme()
+  // already answers "dark" — the cache moved and the store was never told to
+  // re-read it
+  expect(readSubscribedColorScheme()).toBe("dark");
+});
+
+test("the class layer and a subscribed reader agree after one colorScheme.set", () => {
+  registerCSS(TRI_STATE_CSS);
+  render(
+    <>
+      <View testID={testID} className="my-class" />
+      <SubscribedColorScheme />
+    </>,
+  );
+
+  act(() => {
+    colorScheme.set("dark");
+  });
+
+  // The split this API exists to prevent: a `dark:` utility and a subscribed
+  // colour prop rendering different schemes in one tree
+  expect(screen.getByTestId(testID).props.style).toStrictEqual(RED);
+  expect(readSubscribedColorScheme()).toBe("dark");
+  expect(colorScheme.get()).toBe("dark");
 });
 
 test("the class layer resolves the scheme the same way colorScheme.get() does", () => {
@@ -128,8 +238,9 @@ test("set(null) hands the scheme back to Appearance", () => {
     colorScheme.set(null);
   });
 
-  expect(appearance.readSetCalls().at(-1)).toBeNull();
-  expect(appearance.getColorScheme()).toBeNull();
+  // "unspecified" is what RN's setColorScheme sends the platform for null
+  expect(nativeAppearance.readSetColorSchemeCalls().at(-1)).toBe("unspecified");
+  expect(Appearance.getColorScheme()).toBeNull();
   expect(colorScheme.get()).toBe("light");
 });
 
@@ -142,7 +253,7 @@ test("an OS change event repaints a mounted element", () => {
   expect(screen.getByTestId(testID).props.style).toStrictEqual(BLUE);
 
   act(() => {
-    appearance.emitOperatingSystemChange("dark");
+    emitOperatingSystemChange("dark");
   });
 
   expect(screen.getByTestId(testID).props.style).toStrictEqual(RED);

--- a/src/__tests__/native/color-scheme-appearance.test.tsx
+++ b/src/__tests__/native/color-scheme-appearance.test.tsx
@@ -8,7 +8,12 @@ import { colorScheme } from "react-native-css/runtime";
 // A stand-in for Appearance, matching react-native/Libraries/Utilities/Appearance.js:
 // getColorScheme reads a process-lifetime cache and setColorScheme writes it. Under the
 // jest preset the real module is the absent-native branch, where every read is null and
-// setColorScheme is a no-op, so it cannot express this
+// setColorScheme is a no-op, so it cannot express this.
+//
+// It cannot reach useColorScheme, and no fake can: react-native/jest/setup.js:122 replaces
+// that hook with jest.fn(() => "light"), and the real one imports { getColorScheme } from
+// ./Appearance directly rather than through the namespace object replaced below. So the
+// claim that RN's own readers now agree is argued from Appearance's semantics, not tested.
 type ChangeListener = (event: { colorScheme: ColorSchemeName }) => void;
 
 interface FakeAppearance {
@@ -16,17 +21,20 @@ interface FakeAppearance {
   setColorScheme: (scheme: ColorSchemeName) => void;
   addChangeListener: (listener: ChangeListener) => { remove: () => void };
   emitOperatingSystemChange: (scheme: ColorSchemeName) => void;
+  readSetCalls: () => ColorSchemeName[];
 }
 
 jest.mock("react-native", () => {
   const ReactNative = jest.requireActual("react-native");
 
   let cachedScheme: ColorSchemeName = "light";
+  const setCalls: ColorSchemeName[] = [];
   const listeners = new Set<ChangeListener>();
 
   const fakeAppearance: FakeAppearance = {
     getColorScheme: () => cachedScheme,
     setColorScheme: (scheme) => {
+      setCalls.push(scheme);
       cachedScheme = scheme;
     },
     addChangeListener: (listener) => {
@@ -43,6 +51,7 @@ jest.mock("react-native", () => {
         listener({ colorScheme: scheme });
       }
     },
+    readSetCalls: () => setCalls,
   };
 
   Object.defineProperty(ReactNative, "Appearance", {
@@ -55,13 +64,19 @@ jest.mock("react-native", () => {
 
 const appearance = Appearance as unknown as FakeAppearance;
 
-const DARK_SCHEME_CSS = `
-.my-class { color: blue; }
+// Three-way, so "matched neither branch" is distinguishable from "matched light"
+const TRI_STATE_CSS = `
+.my-class { color: green; }
+
+@media (prefers-color-scheme: light) {
+  .my-class { color: blue; }
+}
 
 @media (prefers-color-scheme: dark) {
   .my-class { color: red; }
 }`;
 
+const GREEN = { color: "#008000" } as const;
 const BLUE = { color: "#00f" } as const;
 const RED = { color: "#f00" } as const;
 
@@ -76,32 +91,52 @@ test("colorScheme.set writes through to Appearance, so both readers agree", () =
     colorScheme.set("dark");
   });
 
-  expect(colorScheme.get()).toBe("dark");
+  // The argument, not just the resulting cache: without the write-through the cache
+  // would still read "light" here, but so would a fix that passed the wrong value
+  expect(appearance.readSetCalls().at(-1)).toBe("dark");
   expect(appearance.getColorScheme()).toBe("dark");
 
   act(() => {
     colorScheme.set("light");
   });
 
-  expect(colorScheme.get()).toBe("light");
+  expect(appearance.readSetCalls().at(-1)).toBe("light");
   expect(appearance.getColorScheme()).toBe("light");
 });
 
-test("colorScheme.set repaints a mounted element", () => {
-  registerCSS(DARK_SCHEME_CSS);
-
+test("the class layer resolves the scheme the same way colorScheme.get() does", () => {
+  // The observable holds null at rest and after set(null). Reading it raw leaves every
+  // prefers-color-scheme query unmatched while get() reports a definite scheme, which is
+  // the same two-readers-disagree defect one function along
+  registerCSS(TRI_STATE_CSS);
   render(<View testID={testID} className="my-class" />);
-  expect(screen.getByTestId(testID).props.style).toStrictEqual(BLUE);
 
+  act(() => {
+    colorScheme.set(null);
+  });
+
+  expect(colorScheme.get()).toBe("light");
+  expect(screen.getByTestId(testID).props.style).toStrictEqual(BLUE);
+});
+
+test("set(null) hands the scheme back to Appearance", () => {
   act(() => {
     colorScheme.set("dark");
   });
 
-  expect(screen.getByTestId(testID).props.style).toStrictEqual(RED);
+  act(() => {
+    colorScheme.set(null);
+  });
+
+  expect(appearance.readSetCalls().at(-1)).toBeNull();
+  expect(appearance.getColorScheme()).toBeNull();
+  expect(colorScheme.get()).toBe("light");
 });
 
-test("an OS change event still repaints a mounted element", () => {
-  registerCSS(DARK_SCHEME_CSS);
+test("an OS change event repaints a mounted element", () => {
+  // Guards Appearance.addChangeListener in reactivity.ts, which nothing else covers —
+  // not this change, which does not touch it
+  registerCSS(TRI_STATE_CSS);
 
   render(<View testID={testID} className="my-class" />);
   expect(screen.getByTestId(testID).props.style).toStrictEqual(BLUE);
@@ -111,4 +146,14 @@ test("an OS change event still repaints a mounted element", () => {
   });
 
   expect(screen.getByTestId(testID).props.style).toStrictEqual(RED);
+});
+
+test("a scheme the runtime cannot resolve matches no prefers-color-scheme query", () => {
+  // The unconditional rule is the floor. If both queries ever matched at once, or the
+  // fallback above silently picked a side on a platform that reports nothing, this is
+  // what would catch it
+  registerCSS(`.my-class { color: green; }`);
+  render(<View testID={testID} className="my-class" />);
+
+  expect(screen.getByTestId(testID).props.style).toStrictEqual(GREEN);
 });

--- a/src/__tests__/native/color-scheme-appearance.test.tsx
+++ b/src/__tests__/native/color-scheme-appearance.test.tsx
@@ -1,0 +1,114 @@
+import { Appearance, type ColorSchemeName } from "react-native";
+
+import { act, render, screen } from "@testing-library/react-native";
+import { View } from "react-native-css/components/View";
+import { registerCSS, testID } from "react-native-css/jest";
+import { colorScheme } from "react-native-css/runtime";
+
+// A stand-in for Appearance, matching react-native/Libraries/Utilities/Appearance.js:
+// getColorScheme reads a process-lifetime cache and setColorScheme writes it. Under the
+// jest preset the real module is the absent-native branch, where every read is null and
+// setColorScheme is a no-op, so it cannot express this
+type ChangeListener = (event: { colorScheme: ColorSchemeName }) => void;
+
+interface FakeAppearance {
+  getColorScheme: () => ColorSchemeName;
+  setColorScheme: (scheme: ColorSchemeName) => void;
+  addChangeListener: (listener: ChangeListener) => { remove: () => void };
+  emitOperatingSystemChange: (scheme: ColorSchemeName) => void;
+}
+
+jest.mock("react-native", () => {
+  const ReactNative = jest.requireActual("react-native");
+
+  let cachedScheme: ColorSchemeName = "light";
+  const listeners = new Set<ChangeListener>();
+
+  const fakeAppearance: FakeAppearance = {
+    getColorScheme: () => cachedScheme,
+    setColorScheme: (scheme) => {
+      cachedScheme = scheme;
+    },
+    addChangeListener: (listener) => {
+      listeners.add(listener);
+      return {
+        remove: () => {
+          listeners.delete(listener);
+        },
+      };
+    },
+    emitOperatingSystemChange: (scheme) => {
+      cachedScheme = scheme;
+      for (const listener of listeners) {
+        listener({ colorScheme: scheme });
+      }
+    },
+  };
+
+  Object.defineProperty(ReactNative, "Appearance", {
+    configurable: true,
+    get: () => fakeAppearance,
+  });
+
+  return ReactNative as unknown;
+});
+
+const appearance = Appearance as unknown as FakeAppearance;
+
+const DARK_SCHEME_CSS = `
+.my-class { color: blue; }
+
+@media (prefers-color-scheme: dark) {
+  .my-class { color: red; }
+}`;
+
+const BLUE = { color: "#00f" } as const;
+const RED = { color: "#f00" } as const;
+
+beforeEach(() => {
+  appearance.setColorScheme("light");
+});
+
+test("colorScheme.set writes through to Appearance, so both readers agree", () => {
+  // useColorScheme() reads Appearance, the class layer reads the observable — one
+  // writer has to move both
+  act(() => {
+    colorScheme.set("dark");
+  });
+
+  expect(colorScheme.get()).toBe("dark");
+  expect(appearance.getColorScheme()).toBe("dark");
+
+  act(() => {
+    colorScheme.set("light");
+  });
+
+  expect(colorScheme.get()).toBe("light");
+  expect(appearance.getColorScheme()).toBe("light");
+});
+
+test("colorScheme.set repaints a mounted element", () => {
+  registerCSS(DARK_SCHEME_CSS);
+
+  render(<View testID={testID} className="my-class" />);
+  expect(screen.getByTestId(testID).props.style).toStrictEqual(BLUE);
+
+  act(() => {
+    colorScheme.set("dark");
+  });
+
+  expect(screen.getByTestId(testID).props.style).toStrictEqual(RED);
+});
+
+test("an OS change event still repaints a mounted element", () => {
+  registerCSS(DARK_SCHEME_CSS);
+
+  render(<View testID={testID} className="my-class" />);
+  expect(screen.getByTestId(testID).props.style).toStrictEqual(BLUE);
+
+  act(() => {
+    appearance.emitOperatingSystemChange("dark");
+  });
+
+  expect(screen.getByTestId(testID).props.style).toStrictEqual(RED);
+});

--- a/src/native/api.tsx
+++ b/src/native/api.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable  */
 import { useContext, useState, type ComponentType } from "react";
-import { Appearance } from "react-native";
+import { Appearance, DeviceEventEmitter } from "react-native";
 
 import type { StyleDescriptor } from "react-native-css/compiler";
 import { VariableContext } from "react-native-css/native-internal";
@@ -73,10 +73,30 @@ export const colorScheme: ColorScheme = {
     return colorSchemeObs.get() ?? Appearance.getColorScheme() ?? "light";
   },
   set(value) {
-    // Both readers, in one call: useColorScheme() reads Appearance, the class layer
-    // reads the observable. Moving one without the other splits the app's own UI
+    // Every reader, in one call. There are three, and they are three separate
+    // channels: the class layer reads the observable, useColorScheme() reads
+    // Appearance's cache, and every store built the documented way is wired to
+    // Appearance.addChangeListener. Moving one without the others splits the
+    // app's own UI
+    const previous = Appearance.getColorScheme();
     Appearance.setColorScheme(value);
     colorSchemeObs.set(value);
+
+    // RN's setColorScheme assigns the cache and calls the native module; the
+    // only eventEmitter.emit("change") in Libraries/Utilities/Appearance.js is
+    // inside the `appearanceChanged` handler. So a write the platform does not
+    // echo back moves getColorScheme() and notifies nobody. Announce it on the
+    // same device event the platform uses, so Appearance itself performs the
+    // cache write and the emit exactly as it does for an OS change.
+    //
+    // Guarded on the cache having actually moved, so this reports a change and
+    // never invents one: where there is no native Appearance module the write
+    // above is a no-op and both reads are null, and a redundant set of the
+    // current scheme is silent — matching the observable's own equality guard.
+    const current = Appearance.getColorScheme();
+    if (current !== previous) {
+      DeviceEventEmitter.emit("appearanceChanged", { colorScheme: current });
+    }
   },
 };
 

--- a/src/native/api.tsx
+++ b/src/native/api.tsx
@@ -16,6 +16,7 @@ import { mappingToConfig, useNativeCss } from "./react/useNativeCss";
 import { usePassthrough } from "./react/usePassthrough";
 import {
   colorScheme as colorSchemeObs,
+  resolveColorScheme,
   VAR_SYMBOL,
   type Effect,
   type Getter,
@@ -70,7 +71,7 @@ export const styled = <
 
 export const colorScheme: ColorScheme = {
   get() {
-    return colorSchemeObs.get() ?? Appearance.getColorScheme() ?? "light";
+    return resolveColorScheme(colorSchemeObs.get());
   },
   set(value) {
     // Every reader, in one call. There are three, and they are three separate

--- a/src/native/api.tsx
+++ b/src/native/api.tsx
@@ -83,24 +83,16 @@ export const colorScheme: ColorScheme = {
     const previous = Appearance.getColorScheme();
 
     // Resolved BEFORE the write, because on react-native 0.82.0-0.84.1 the
-    // write is what destroys the ability to resolve. That band caches the
+    // write is what destroys the ability to resolve: that band caches the
     // REQUESTED value verbatim, so a follow-the-system request leaves
-    // Appearance.getColorScheme() answering the literal "unspecified" — and
-    // that cache is the one source resolveColorScheme falls back to when the
-    // observable is holding a hand-back. react-native repaired it in 0.85.3 by
-    // caching the scheme in force instead; on the band that did not, this is
-    // the scheme in force.
+    // Appearance.getColorScheme() answering the literal "unspecified" to every
+    // reader in the app. react-native removed that in 0.85.3 by caching the
+    // scheme in force instead; on the band that did not, this is the scheme in
+    // force.
     const inForce = resolveColorScheme(colorSchemeObs.get());
 
     Appearance.setColorScheme(value);
-
-    // A hand-back is stored as itself wherever the cache can still answer, so
-    // an OS change is still what decides the scheme. Where the cache is now
-    // holding a request rather than an answer, the observable is the only
-    // channel left that can, and it holds what the request resolves to.
-    colorSchemeObs.set(
-      holdsRequestNotScheme(Appearance.getColorScheme()) ? inForce : value,
-    );
+    colorSchemeObs.set(value);
 
     // RN's setColorScheme assigns the cache and calls the native module; the
     // only eventEmitter.emit("change") in Libraries/Utilities/Appearance.js is
@@ -127,6 +119,18 @@ export const colorScheme: ColorScheme = {
     // change. `previous` keeps a set of the scheme already in force silent.
     if ((value === "dark" || value === "light") && value !== previous) {
       DeviceEventEmitter.emit("appearanceChanged", { colorScheme: value });
+    } else if (holdsRequestNotScheme(Appearance.getColorScheme())) {
+      // The hand-back went through, and on 0.82.0-0.84.1 it left react-native's
+      // own cache holding the request. That cache is not this library's — it is
+      // what `useColorScheme()` and every documented store read — so routing
+      // around it would leave the app answering "unspecified" while this
+      // library answered correctly. Put the scheme in force back where every
+      // reader looks for it, on the same device event the platform uses, and
+      // Appearance performs the cache write and the emit exactly as it does for
+      // an OS change. Nothing is announced on the bands whose cache can still
+      // answer, because there the platform's own echo is still the only thing
+      // that should move the scheme.
+      DeviceEventEmitter.emit("appearanceChanged", { colorScheme: inForce });
     }
   },
 };

--- a/src/native/api.tsx
+++ b/src/native/api.tsx
@@ -89,13 +89,23 @@ export const colorScheme: ColorScheme = {
     // same device event the platform uses, so Appearance itself performs the
     // cache write and the emit exactly as it does for an OS change.
     //
-    // Guarded on the cache having actually moved, so this reports a change and
-    // never invents one: where there is no native Appearance module the write
-    // above is a no-op and both reads are null, and a redundant set of the
-    // current scheme is silent — matching the observable's own equality guard.
-    const current = Appearance.getColorScheme();
-    if (current !== previous) {
-      DeviceEventEmitter.emit("appearanceChanged", { colorScheme: current });
+    // The announcement carries the REQUESTED scheme rather than a read of the
+    // cache, because what that cache holds at this point differs across the
+    // supported range: from 0.86 it is the requested value, and before that it
+    // is a read-back of the native module, which is stale on both platforms —
+    // Android posts the night-mode switch to the UI thread, iOS never assigns
+    // _currentColorScheme in the setter. Reading it back would make this an
+    // announcement on one react-native and a no-op on another.
+    //
+    // Only a resolved scheme is announced. Every other member of
+    // ColorSchemeName is a hand-back rather than a scheme — null and undefined
+    // before 0.86, the literal "unspecified" from 0.86 on — and only the OS
+    // knows what one resolves to. Announcing it would put a value in
+    // Appearance's cache that no reader can render; the platform's own echo
+    // delivers the resolved scheme instead, exactly as it does for an OS
+    // change. `previous` keeps a set of the scheme already in force silent.
+    if ((value === "dark" || value === "light") && value !== previous) {
+      DeviceEventEmitter.emit("appearanceChanged", { colorScheme: value });
     }
   },
 };

--- a/src/native/api.tsx
+++ b/src/native/api.tsx
@@ -16,6 +16,7 @@ import { mappingToConfig, useNativeCss } from "./react/useNativeCss";
 import { usePassthrough } from "./react/usePassthrough";
 import {
   colorScheme as colorSchemeObs,
+  holdsRequestNotScheme,
   resolveColorScheme,
   VAR_SYMBOL,
   type Effect,
@@ -80,8 +81,26 @@ export const colorScheme: ColorScheme = {
     // Appearance.addChangeListener. Moving one without the others splits the
     // app's own UI
     const previous = Appearance.getColorScheme();
+
+    // Resolved BEFORE the write, because on react-native 0.82.0-0.84.1 the
+    // write is what destroys the ability to resolve. That band caches the
+    // REQUESTED value verbatim, so a follow-the-system request leaves
+    // Appearance.getColorScheme() answering the literal "unspecified" — and
+    // that cache is the one source resolveColorScheme falls back to when the
+    // observable is holding a hand-back. react-native repaired it in 0.85.3 by
+    // caching the scheme in force instead; on the band that did not, this is
+    // the scheme in force.
+    const inForce = resolveColorScheme(colorSchemeObs.get());
+
     Appearance.setColorScheme(value);
-    colorSchemeObs.set(value);
+
+    // A hand-back is stored as itself wherever the cache can still answer, so
+    // an OS change is still what decides the scheme. Where the cache is now
+    // holding a request rather than an answer, the observable is the only
+    // channel left that can, and it holds what the request resolves to.
+    colorSchemeObs.set(
+      holdsRequestNotScheme(Appearance.getColorScheme()) ? inForce : value,
+    );
 
     // RN's setColorScheme assigns the cache and calls the native module; the
     // only eventEmitter.emit("change") in Libraries/Utilities/Appearance.js is

--- a/src/native/api.tsx
+++ b/src/native/api.tsx
@@ -73,7 +73,10 @@ export const colorScheme: ColorScheme = {
     return colorSchemeObs.get() ?? Appearance.getColorScheme() ?? "light";
   },
   set(value) {
-    return colorSchemeObs.set(value);
+    // Both readers, in one call: useColorScheme() reads Appearance, the class layer
+    // reads the observable. Moving one without the other splits the app's own UI
+    Appearance.setColorScheme(value);
+    colorSchemeObs.set(value);
   },
 };
 

--- a/src/native/api.tsx
+++ b/src/native/api.tsx
@@ -92,15 +92,16 @@ export const colorScheme: ColorScheme = {
     //
     // The announcement carries the REQUESTED scheme rather than a read of the
     // cache, because what that cache holds at this point differs across the
-    // supported range: from 0.86 it is the requested value, and before that it
-    // is a read-back of the native module, which is stale on both platforms —
-    // Android posts the night-mode switch to the UI thread, iOS never assigns
-    // _currentColorScheme in the setter. Reading it back would make this an
-    // announcement on one react-native and a no-op on another.
+    // supported range: before 0.82 it is a read-back of the native module,
+    // which is stale on both platforms — Android posts the night-mode switch to
+    // the UI thread, iOS never assigns _currentColorScheme in the setter —
+    // while from 0.82 a resolved scheme is stored as requested. Reading it back
+    // would make this an announcement on one react-native and a no-op on
+    // another.
     //
     // Only a resolved scheme is announced. Every other member of
     // ColorSchemeName is a hand-back rather than a scheme — null and undefined
-    // before 0.86, the literal "unspecified" from 0.86 on — and only the OS
+    // before 0.82, the literal "unspecified" from 0.82 on — and only the OS
     // knows what one resolves to. Announcing it would put a value in
     // Appearance's cache that no reader can render; the platform's own echo
     // delivers the resolved scheme instead, exactly as it does for an OS

--- a/src/native/conditions/media-query.ts
+++ b/src/native/conditions/media-query.ts
@@ -1,5 +1,5 @@
 /* eslint-disable */
-import { I18nManager, PixelRatio, Platform } from "react-native";
+import { Appearance, I18nManager, PixelRatio, Platform } from "react-native";
 
 import type { MediaCondition } from "react-native-css/compiler";
 
@@ -45,7 +45,12 @@ function testComparison(mediaQuery: MediaCondition, get: Getter): Boolean {
     case "platform":
       return value === "native" || value === Platform.OS;
     case "prefers-color-scheme": {
-      return value === get(colorScheme);
+      // The same resolution the public colorScheme.get() uses. Reading the raw
+      // observable instead leaves the class layer matching neither light nor dark
+      // whenever it holds null — which is its value at rest, and after set(null)
+      return (
+        value === (get(colorScheme) ?? Appearance.getColorScheme() ?? "light")
+      );
     }
     case "display-mode":
       return value === "native" || Platform.OS === value;

--- a/src/native/conditions/media-query.ts
+++ b/src/native/conditions/media-query.ts
@@ -1,9 +1,15 @@
 /* eslint-disable */
-import { Appearance, I18nManager, PixelRatio, Platform } from "react-native";
+import { I18nManager, PixelRatio, Platform } from "react-native";
 
 import type { MediaCondition } from "react-native-css/compiler";
 
-import { colorScheme, vh, vw, type Getter } from "../reactivity";
+import {
+  colorScheme,
+  resolveColorScheme,
+  vh,
+  vw,
+  type Getter,
+} from "../reactivity";
 
 export function testMediaQuery(mediaQueries: MediaCondition[], get: Getter) {
   return mediaQueries.every((query) => test(query, get));
@@ -45,12 +51,12 @@ function testComparison(mediaQuery: MediaCondition, get: Getter): Boolean {
     case "platform":
       return value === "native" || value === Platform.OS;
     case "prefers-color-scheme": {
-      // The same resolution the public colorScheme.get() uses. Reading the raw
-      // observable instead leaves the class layer matching neither light nor dark
-      // whenever it holds null — which is its value at rest, and after set(null)
-      return (
-        value === (get(colorScheme) ?? Appearance.getColorScheme() ?? "light")
-      );
+      // The same resolution the public colorScheme.get() uses — through the one
+      // function both call, so the class layer and the prop layer cannot answer
+      // differently. Reading the raw observable instead leaves this matching
+      // neither light nor dark whenever it holds a non-scheme: null at rest and
+      // after set(null), "unspecified" after a follow-the-system request on 0.86
+      return value === resolveColorScheme(get(colorScheme));
     }
     case "display-mode":
       return value === "native" || Platform.OS === value;

--- a/src/native/conditions/media-query.ts
+++ b/src/native/conditions/media-query.ts
@@ -55,7 +55,7 @@ function testComparison(mediaQuery: MediaCondition, get: Getter): Boolean {
       // function both call, so the class layer and the prop layer cannot answer
       // differently. Reading the raw observable instead leaves this matching
       // neither light nor dark whenever it holds a non-scheme: null at rest and
-      // after set(null), "unspecified" after a follow-the-system request on 0.86
+      // after set(null), "unspecified" after a follow-the-system request on 0.82+
       return value === resolveColorScheme(get(colorScheme));
     }
     case "display-mode":

--- a/src/native/reactivity.ts
+++ b/src/native/reactivity.ts
@@ -256,6 +256,28 @@ export function resolveColorScheme(held: ColorSchemeName): "light" | "dark" {
   return reported === "light" || reported === "dark" ? reported : "light";
 }
 
+/**
+ * Whether `Appearance`'s cache is holding a REQUEST rather than an answer.
+ *
+ * `NativeAppearance.getColorScheme()` cannot produce one on either platform:
+ * Android resolves the configuration to "dark" or "light"
+ * (`AppearanceModule.colorSchemeForCurrentConfiguration`) and iOS returns
+ * `_currentColorScheme`. So the only way a non-nullish non-scheme reaches that
+ * cache is react-native 0.82.0-0.84.1 storing a `setColorScheme` argument
+ * verbatim — the band between the read-back 0.81 performs on every path and the
+ * read-back 0.85.3 restored for `"unspecified"` alone.
+ *
+ * Nullish is not that, and stays a real answer: it means the platform reports
+ * no scheme at all, which is what the `"light"` last resort is for.
+ */
+export function holdsRequestNotScheme(held: ColorSchemeName): boolean {
+  return held !== null && held !== undefined && !isScheme(held);
+}
+
+function isScheme(held: ColorSchemeName): held is "light" | "dark" {
+  return held === "light" || held === "dark";
+}
+
 /** Containers ****************************************************************/
 
 export type ContainerContextValue = Record<string, WeakKey>;

--- a/src/native/reactivity.ts
+++ b/src/native/reactivity.ts
@@ -221,6 +221,41 @@ export const colorScheme = observable<ColorSchemeName>(
 );
 Appearance.addChangeListener((event) => colorScheme.set(event.colorScheme));
 
+/**
+ * What a reader renders, from whatever the scheme channel is holding.
+ *
+ * Totalized over the scheme UNION rather than over nullishness, and that is the
+ * whole of it. `"unspecified"` is react-native 0.86's spelling of "follow the
+ * system" — the request 0.81 spells `null` — so it is a REQUEST, never a scheme.
+ * A `?? Appearance.getColorScheme() ?? "light"` chain only fires on nullish, so
+ * the literal passes straight through, and a reader handed it matches neither
+ * `prefers-color-scheme: dark` nor `: light`: every scheme-conditional class
+ * goes dead rather than falling back. On Android nothing repairs that until the
+ * user toggles the system theme, because `AppearanceModule` emits only when the
+ * RESOLVED scheme changes.
+ *
+ * It accepts a resolved scheme and rejects everything else, rather than naming
+ * the members it must reject. That is what makes it total: a future release can
+ * add another "no scheme yet" spelling and this keeps answering correctly,
+ * where a deny-list would silently gain a third hole. It is also why nothing
+ * here compares against `"unspecified"`, which is outside the `ColorSchemeName`
+ * the installed react-native declares.
+ *
+ * One function rather than the expression written at each reader, because both
+ * readers have to give the SAME answer — the class layer and the prop layer
+ * disagreeing about the scheme is the defect, not the duplication. The two
+ * copies this replaces had already drifted into being wrong together.
+ *
+ * `"light"` is the last resort, per MQ5 §5.4.
+ */
+export function resolveColorScheme(held: ColorSchemeName): "light" | "dark" {
+  if (held === "light" || held === "dark") {
+    return held;
+  }
+  const reported = Appearance.getColorScheme();
+  return reported === "light" || reported === "dark" ? reported : "light";
+}
+
 /** Containers ****************************************************************/
 
 export type ContainerContextValue = Record<string, WeakKey>;

--- a/src/native/reactivity.ts
+++ b/src/native/reactivity.ts
@@ -225,7 +225,7 @@ Appearance.addChangeListener((event) => colorScheme.set(event.colorScheme));
  * What a reader renders, from whatever the scheme channel is holding.
  *
  * Totalized over the scheme UNION rather than over nullishness, and that is the
- * whole of it. `"unspecified"` is react-native 0.86's spelling of "follow the
+ * whole of it. `"unspecified"` is react-native 0.82's spelling of "follow the
  * system" — the request 0.81 spells `null` — so it is a REQUEST, never a scheme.
  * A `?? Appearance.getColorScheme() ?? "light"` chain only fires on nullish, so
  * the literal passes straight through, and a reader handed it matches neither


### PR DESCRIPTION
## Problem

`colorScheme.set()` moves this library's observable and nothing else, so the two halves of an app's theming disagree.

The class layer (`dark:` utilities, `@media (prefers-color-scheme)`) reads the observable. React Native's own readers — `useColorScheme()` and every prop-valued colour — read `Appearance`. An app calling the documented setter moves the first and not the second, and renders a light canvas under dark chrome.

```js
import { colorScheme } from 'react-native-css/runtime';
import { Appearance } from 'react-native';

colorScheme.set('dark');
Appearance.getColorScheme();   // 'light' — useColorScheme() still reports light
```

**This is a native-only change, and "every reader" is a claim about the native runtime.** `src/web/api.tsx` already intends to write through to `Appearance`, and on web that call is a hard `TypeError` — a pre-existing defect this deliberately does not close, described in full in the last section.

## Fix

Three parts, all about the same thing — the library had two sources of truth for the scheme, and moving one of them told nobody.

**The setter reaches all three readers**, which are three separate channels: the class layer reads the observable, `useColorScheme()` reads `Appearance`'s cache, and every store built the documented way is subscribed through `Appearance.addChangeListener`.

```ts
set(value) {
  const previous = Appearance.getColorScheme();
  Appearance.setColorScheme(value);
  colorSchemeObs.set(value);

  if ((value === "dark" || value === "light") && value !== previous) {
    DeviceEventEmitter.emit("appearanceChanged", { colorScheme: value });
  }
},
```

**And the class layer resolves the scheme the way `colorScheme.get()` already does.** `get()` coalesces through `Appearance` to a definite value; `conditions/media-query.ts` read the raw observable. That observable holds `null` at rest and after `set(null)`, so `prefers-color-scheme: light` and `dark` both failed while `get()` reported `light`, and the element fell through to its unconditional rule. Same defect as above, one function along, and reachable through the setter this PR changes:

```ts
value === (get(colorScheme) ?? Appearance.getColorScheme() ?? "light")
```

### Why the announcement goes through `DeviceEventEmitter`

Because that is the channel `Appearance` itself listens on, and React Native provides no other way in.

`Libraries/Utilities/Appearance.js` has two write paths and only one of them emits. `setColorScheme` assigns `state.appearance` and calls the native module; the sole `eventEmitter.emit('change', …)` sits inside the `appearanceChanged` handler registered in `getState()`. So a write the platform does not echo back moves `getColorScheme()` and notifies nobody — and `useColorScheme` is `useSyncExternalStore(addChangeListener, getColorScheme)`, so with no event it is never told to re-read. Neither is any other store built the same way, which is every documented way to track the scheme.

That handler is registered through `new NativeEventEmitter(NativeAppearance).addListener('appearanceChanged', …)`, and `NativeEventEmitter.addListener` registers on `RCTDeviceEventEmitter` — its own comment says so ("all native events are fired via a global `RCTDeviceEventEmitter`"). `DeviceEventEmitter` is that emitter, exported from the `react-native` root (`index.js`, and `types/index.d.ts`). So emitting there hands the value to `Appearance`, which performs its own cache write and its own `change` emit, exactly as it does for an OS change. The library invents no notification and reimplements none of `Appearance`'s behaviour.

### Why it carries the requested scheme rather than a read of the cache

Because `setColorScheme` writes that cache differently on either side of react-native 0.86, and the declared peer range (`react-native >= 0.81`) spans the change.

```js
// react-native 0.81.4 — a read-back of the native module, on every path
NativeAppearance.setColorScheme(colorScheme ?? 'unspecified');
state.appearance = {colorScheme: toColorScheme(NativeAppearance.getColorScheme())};

// react-native 0.86.0 — the requested value, read back only for "unspecified"
NativeAppearance.setColorScheme(colorScheme);
state.appearance = {
  colorScheme:
    colorScheme === 'unspecified'
      ? (NativeAppearance.getColorScheme() ?? colorScheme)
      : colorScheme,
};
```

**Before 0.86 that read-back is stale on both platforms**, because the platform applies the write on a later turn:

- **Android** — `AppearanceModule.setColorScheme` wraps the night-mode switch in `UiThreadUtil.runOnUiThread {}`, and `runOnUiThread` is `mainHandler.postDelayed(runnable, 0)`: always posted, never run inline. `getColorScheme()` still answers from the configuration in force.
- **iOS** — `RCTAppearance.mm`'s `getColorScheme` returns `_currentColorScheme`, which is assigned at `init` and inside `appearanceChanged:` and never by `setColorScheme:` — that method sets `window.overrideUserInterfaceStyle` and nothing else.

So a guard that reads the cache back concludes "nothing moved" on every react-native below 0.86 and suppresses its own emit; subscribers are left to the platform echo, which is exactly where they were before. From 0.86 the same guard fires — including on `set(null)`, where the cache goes `null` and the announcement broadcasts `{colorScheme: null}` to every subscriber, telling `useColorScheme()` the app has no scheme at all.

Keying on the requested scheme takes the version out of the question: the announcement says the same thing on every react-native in the peer range, because it never asks what the platform did with the write.

**Only a resolved scheme is announced.** Every other member of `ColorSchemeName` is a hand-back rather than a scheme, and that type moved at the same release — 0.81 declares `'light' | 'dark' | null | undefined`, 0.86 declares `'light' | 'dark' | 'unspecified'`, so on the current release `"unspecified"` is the type-legal way to hand the scheme back and `null` is not in the type at all. Only the OS knows what a hand-back resolves to. Announcing the request itself would put a value in `Appearance`'s cache that no reader can render, and on 0.81 `"unspecified"` trips `toColorScheme`'s invariant outright; the platform's own echo delivers the resolved scheme instead, exactly as it does for an OS change. `previous` is what keeps a set of the scheme already in force silent.

**The guard is well-typed on both**, which is worth saying because `ColorSchemeName` inverted at the same release: comparing against the two scheme literals narrows identically under `'light' | 'dark' | null | undefined` and under `'light' | 'dark' | 'unspecified'`, so the line adds no error to a `tsc` run on either. `yarn typecheck` here runs against the 0.81 pin; the 0.86 union was checked by replaying the expression against it directly.

**Nothing in `src/compiler` is touched or reachable.** The compiler emits the `["=", "prefers-color-scheme", "dark"]` condition tuple and never resolves it — its only import from `react-native` is the `PlatformOSType` type — so both halves of this change are confined to the native runtime that evaluates the tuple.

**One notification per `colorScheme.set`, and the guard is not what bounds it.** The emit drives `Appearance`'s `change`, which drives this library's own subscription (`reactivity.ts:222`), which calls `colorSchemeObs.set(event.colorScheme)` with the value the line above already wrote — and `observable.set`'s `Object.is` early return (`reactivity.ts:73-93`) is what makes that second write notify nobody. Removing the guard entirely still terminates cleanly (column C below): it announces redundantly, it does not recurse.

**The real home for this is `Appearance.setColorScheme` itself**, which should announce a cache it just moved. This is the library-side close; I am happy to take it upstream to react-native as well if you would rather have it there.

### Known limits, precisely

**A platform that echoes the write back delivers two `change` events with the same value.** Measured as `["dark", "dark"]` for one `colorScheme.set("dark")` followed by the echo, in both new suites. iOS sets `overrideUserInterfaceStyle`, which fires a trait change `RCTAppearance` re-emits; Android's `setDefaultNightMode` reaches `onConfigurationChanged`. Both dedup against their own last emission, and neither can see a `DeviceEventEmitter.emit` made in JS, so the echo still arrives. `useSyncExternalStore` bails on an identical snapshot, so `useColorScheme` re-renders once and any other subscriber sees an idempotent repeat. React Native makes no dedup guarantee on this event in the first place.

**A hand-back followed by a set of the scheme the stale cache happens to hold announces nothing.** Measured against the 0.86 model: `set("dark")`, then `set("unspecified")`, then `set("light")` before the platform echo lands, leaves subscribers on `"dark"` while `Appearance.getColorScheme()` already reads `"light"`. `previous` is read from a cache that `setColorScheme`'s own read-back can move without notifying anybody, so it is not reliably what subscribers last heard. Closing it means the setter tracking what it last announced — state it does not otherwise need — so I have left it open rather than add that unasked.

**I have not measured this on hardware.** The mechanism is read off react-native's own source (0.81.4 and 0.86.0, JS and both native modules) and measured in the suite; not on a device.

**A direct `Appearance.setColorScheme()` still does not move an already-mounted element.** That is unchanged by this PR and is a different defect: the observable is seeded once at import and never re-read, so a fresh mount after a direct write is stale too — no notification would fix that, and no pull would either. Making it work means the class layer subscribing to `Appearance` rather than mirroring it, which is a change to how the observable is constructed and a separate question from this one.

Reading `Appearance` through on every observable `get()` is the obvious way to try, and it is a trap worth recording: `get()` on a *function-init* observable assigns the cached value without notifying, while `run()`'s equality guard compares against that same cache. A read landing between a change and its notification swallows the notification, permanently. I measured that as two elements with the same class rendering different colours. It does not apply to the observable as it stands — seeded with a value, it is static — but it is why the read-through is not the shortcut it looks like.

## Tests

Eighteen, across three files. Each column below reverts or alters one half of the change; every test is killed by at least one, except the last, which is the floor by design.

| | A revert the write-through | B announce nothing | C announce on every call | D announce a cache read-back | E announce every non-null value | F revert the media-query fallback | G remove the change listener |
| --- | --- | --- | --- | --- | --- | --- | --- |
| **`color-scheme-appearance.test.tsx`** | | | | | | | |
| writes through to Appearance | **red** | | | | | | |
| notifies Appearance's subscribers | | **red** | | | | | |
| a set to the scheme already in force announces nothing | | | **red** | | | | |
| a reader subscribed the way `useColorScheme` is moves | | **red** | | | | | |
| the class layer and a subscribed reader agree | | **red** | | | | | |
| the class layer resolves like `get()` | | | | | | **red** | |
| `set(null)` hands the scheme back | **red** | | | | | | |
| an OS change repaints a mounted element | | | | | | | **red** |
| an unresolvable scheme matches no query | | | | | | | — the floor |
| **`color-scheme-appearance-async.test.tsx`** | | | | | | | |
| announces before the platform applies | | **red** | | **red** | | | |
| a subscribed reader moves before the echo | | **red** | | **red** | | | |
| the echo repeats the scheme and settles | **red** | **red** | | **red** | | | |
| a redundant set says nothing | | | **red** | | | | |
| `set(null)` announces no scheme of its own | | | **red** | | | | |
| **`color-scheme-appearance-rn-0-86.test.tsx`** | | | | | | | |
| announces the requested scheme once | **red** | **red** | | | | | |
| `set(null)` broadcasts no null scheme | | | **red** | **red** | | | |
| `set('unspecified')` broadcasts no literal | | | **red** | | **red** | | **red** |
| a redundant set announces nothing | **red** | | **red** | | | | |

Column **D** is a cache-derived announcement, which is what makes the read-back dependency measurable rather than argued: it passes every test in the original suite and fails four here. Column **E** is the same guard without the resolved-scheme test — the one mutation that reaches only the 0.86 literal.

**The 0.81 suites fake `Libraries/Utilities/NativeAppearance`, not `Appearance`.** Under the jest preset `TurboModuleRegistry.get("Appearance")` is null, so the real module takes its absent-native branch — every read `null`, `setColorScheme` a no-op, and no `appearanceChanged` listener registered — which is why it cannot express the behaviour under test. Faking the one module it is missing leaves the real `Appearance.js` running, so its cache, its `change` emit, its `unspecified` coercion and their ordering are react-native's own rather than a transcription of them.

`color-scheme-appearance-async.test.tsx` is that same instrument over a native module that applies the write **on a later turn**, through an explicit flush seam rather than a timer, which is what a device does. `color-scheme-appearance-rn-0-86.test.tsx` is the one file that transcribes rather than runs: 0.86's `Appearance.js` cannot be installed beside the 0.81 this repo pins, so its four functions are transcribed and quoted, and the `appearanceChanged` registration is still react-native's own `NativeEventEmitter` — what reaches that cache is what reaches the real one. Transcribing the version that cannot be installed, and only that, is the whole of the fakery.

The write-through test asserts the **argument** passed to `setColorScheme`, not the resulting cache. Asserting the cache passes under every mutation, because `get()` falls back to `Appearance.getColorScheme()` and either writer alone satisfies it.

The subscriber tests render `useSyncExternalStore(addChangeListener, getColorScheme)` — the exact shape of `useColorScheme`, which cannot itself be used because `react-native/jest/setup.js` replaces it with `jest.fn(() => "light")`.

The `prefers-color-scheme` fixture is three-way — unconditional green, `light` blue, `dark` red — so "matched neither branch" is distinguishable from "matched light". The `set(null)` defect is invisible to a two-colour fixture.

Full suite on Windows: `3 failed, 21 skipped, 1083 passed, 1107 total` tests. Each commit added exactly its own tests and changed no failure: `1057` before this one, `1067` after it, `1083` after the third below. The three that fail are the `src/__tests__/babel/*` path suites, unrelated to this change and fixed by #390. `yarn typecheck` and `yarn lint` both exit 0.

## Second commit — `"unspecified"` was leaking through the same resolution

The first commit makes this package's own `set` move every reader. Reviewing it turned up a second hole in the resolution it leans on, reproducible on its own.

Both readers resolved the scheme with `?? Appearance.getColorScheme() ?? "light"`. That chain fires only on a **nullish** value, and `"unspecified"` is not nullish — it is 0.86's spelling of "follow the system", where 0.81 spells `null`. So the literal passes straight through to a reader.

A reader handed it matches neither `prefers-color-scheme: dark` nor `: light`, so an app that asks to follow a **dark** system loses every scheme-conditional class rather than falling back to one. On Android nothing repairs that until the user toggles the system theme, because `AppearanceModule` emits only when the *resolved* scheme changes.

The existing `set('unspecified')` test could not see it: it asserts only **after** the platform echo, which repairs the value. The new test asserts inside that window, and fails on the parent commit with `Expected: not "unspecified"`.

`resolveColorScheme` accepts a resolved scheme and rejects everything else, rather than naming the members it must reject. That is what makes it total — a future release can add another "no scheme yet" spelling and it keeps answering correctly, where a deny-list would silently gain a third hole. It is also why nothing in it compares against `"unspecified"`, which is outside the `ColorSchemeName` the pinned react-native declares.

Both readers call the one function, because the class layer and the prop layer disagreeing about the scheme is the defect itself — and the two copies it replaces had already drifted into being wrong together. The `media-query.ts` copy even carried the comment "The same resolution the public `colorScheme.get()` uses", which is the invariant this makes structural instead of conventional.

## Third commit — repairing react-native's own cache on 0.82.0–0.84.1

The fix above stores the resolved scheme in this library's observable and announces it. On react-native 0.82.0–0.84.1 that is not enough: those versions cache the **requested** value verbatim, so a `colorScheme.set(null)` hand-back leaves `Appearance.getColorScheme()` answering the literal `"unspecified"` to every reader in the app — `useColorScheme()` included.

That cache is not this library's, and `colorScheme.set` is what put the request there. Routing around it would leave the app answering `"unspecified"` while this library answered correctly, so the setter repairs it where every reader looks:

```ts
} else if (holdsRequestNotScheme(Appearance.getColorScheme())) {
  DeviceEventEmitter.emit("appearanceChanged", { colorScheme: inForce });
}
```

`inForce` is resolved **before** the write, because on that band the write is what destroys the ability to resolve it.

`holdsRequestNotScheme` is deliberately narrow. `NativeAppearance.getColorScheme()` cannot produce a non-scheme on either platform — Android resolves the configuration to `"dark"` or `"light"` in `AppearanceModule.colorSchemeForCurrentConfiguration`, iOS returns `_currentColorScheme` — so the only way a non-nullish non-scheme reaches that cache is 0.82.0–0.84.1 storing a `setColorScheme` argument verbatim. That is exactly the band between the read-back 0.81 performs on every path and the read-back 0.85.3 restored for `"unspecified"` alone. Nullish is not that and stays a real answer: it means the platform reports no scheme at all, which is what the `"light"` last resort is for.

Nothing is announced on the bands whose cache can still answer, so there the platform's own echo remains the only thing that moves the scheme.

One branch carries the whole band, and it is mutation-proven: removing it turns exactly four assertions red together — the resolved scheme, the class layer, react-native's cache, and the no-echo case. That is how the new suite is written — every cache-write rule in the declared peer range's census, asserted against react-native's cache *after* the request rather than against the argument passed in. It adds 16 tests.

## Note

This changes the observable behaviour of a public API, which `CONTRIBUTING.md` asks be discussed in an issue first. Happy to move it to one if you would rather — I opened it as a PR because the change and its reproduction are easier to read as a diff.

## Separately, the web half of this API is broken

`src/web/api.tsx:76` calls `Appearance.setColorScheme(name)`, and `react-native-web@0.21.1` does not implement it — its `Appearance` exports exactly `getColorScheme` and `addChangeListener`. So that call is a `TypeError` for the first caller.

Nothing in the repo can see it: `src/web/api.tsx:8` imports `Appearance` from `"react-native"`, so TypeScript resolves RN's `.d.ts`, which *does* declare `setColorScheme`, and the swap to react-native-web happens at bundler resolution. There are no runtime tests under `src/web/**` at all. It predates this change (`aeb0085`).

**I have deliberately not fixed it here, because it is not a missing line — it is a missing concept.** A browser will not let JavaScript override `prefers-color-scheme`; react-native-web has no `setColorScheme` because there is nothing for it to do. So closing it means deciding what `colorScheme.set` *means* on web, and there are three different answers:

1. **Guard the call** — a capability check turns the crash into a silent no-op. Version-tolerant if react-native-web ever adds the method, but a documented setter that quietly does nothing is arguably worse than one that throws.
2. **Throw a named error** saying web cannot override the browser's media query, so the failure names its own cause.
3. **Implement a real web override** — a class or attribute on the root plus a compiled fallback for `@media (prefers-color-scheme)`, so `dark:` follows the library rather than the browser. That is a feature, not a fix.

That is your call rather than mine, and it changes what a public API promises on a platform this PR does not otherwise touch — so it wants its own PR and probably its own issue. Happy to send whichever of the three you want.


