### PR TITLE
fix(types): accept an explicit undefined on every prop this package adds

### DIFF
--- a/package.json
+++ b/package.json
@@ -165,7 +165,7 @@
     "start:build": "yarn build && yarn example build",
     "start:debug": "yarn build && yarn example debug",
     "test": "NODE_OPTIONS=\"${NODE_OPTIONS:-} --experimental-vm-modules\" jest",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit && tsc --noEmit -p src/__tests__/types"
   },
   "keywords": [
     "react-native",

--- a/src/__tests__/types/_exact-optional-props.tsx
+++ b/src/__tests__/types/_exact-optional-props.tsx
@@ -1,0 +1,103 @@
+import type {
+  ButtonProps,
+  FlatListProps,
+  ImageBackgroundProps,
+  ImageProps,
+  InputAccessoryViewProps,
+  KeyboardAvoidingViewProps,
+  ModalProps,
+  ScrollViewProps,
+  StatusBarProps,
+  SwitchProps,
+  TextInputProps,
+  TextProps,
+  TouchableWithoutFeedbackProps,
+  ViewProps,
+} from "react-native";
+
+import type { VirtualizedListWithoutRenderItemProps } from "@react-native/virtualized-lists";
+
+// Every prop this package adds must accept an explicit `undefined`, as React Native's own
+// optional props already do. Under `exactOptionalPropertyTypes` a bare `?: string` rejects
+// it, so `className={condition ? "p-4" : undefined}` — the ordinary conditional — fails.
+// This file compiles with that flag on; the root typecheck cannot observe the difference.
+declare const maybeString: string | undefined;
+declare const maybeBoolean: boolean | undefined;
+declare const noop: () => void;
+
+export const view: ViewProps = {
+  className: maybeString,
+  cssInterop: maybeBoolean,
+};
+
+export const text: TextProps = {
+  className: maybeString,
+  cssInterop: maybeBoolean,
+};
+
+export const image: ImageProps = {
+  className: maybeString,
+  cssInterop: maybeBoolean,
+};
+
+export const switchProps: SwitchProps = {
+  className: maybeString,
+  cssInterop: maybeBoolean,
+};
+
+export const inputAccessoryView: InputAccessoryViewProps = {
+  className: maybeString,
+  cssInterop: maybeBoolean,
+};
+
+export const touchableWithoutFeedback: TouchableWithoutFeedbackProps = {
+  className: maybeString,
+  cssInterop: maybeBoolean,
+};
+
+export const statusBar: StatusBarProps = {
+  className: maybeString,
+  cssInterop: maybeBoolean,
+};
+
+export const button: ButtonProps = {
+  title: "",
+  onPress: noop,
+  className: maybeString,
+};
+
+export const scrollView: ScrollViewProps = {
+  contentContainerClassName: maybeString,
+  indicatorClassName: maybeString,
+};
+
+export const flatList: FlatListProps<unknown> = {
+  data: [],
+  renderItem: () => null,
+  columnWrapperClassName: maybeString,
+};
+
+export const imageBackground: ImageBackgroundProps = {
+  source: 0,
+  imageClassName: maybeString,
+};
+
+export const textInput: TextInputProps = {
+  placeholderClassName: maybeString,
+};
+
+export const keyboardAvoidingView: KeyboardAvoidingViewProps = {
+  contentContainerClassName: maybeString,
+};
+
+export const modal: ModalProps = {
+  presentationClassName: maybeString,
+};
+
+export const virtualizedList: VirtualizedListWithoutRenderItemProps<unknown> = {
+  data: [],
+  getItem: () => undefined,
+  getItemCount: () => 0,
+  ListFooterComponentClassName: maybeString,
+  ListHeaderComponentClassName: maybeString,
+};

--- a/src/__tests__/types/tsconfig.json
+++ b/src/__tests__/types/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../../tsconfig.json",
+  "compilerOptions": {
+    "exactOptionalPropertyTypes": true
+  },
+  "include": ["./*"],
+  "files": ["../../../types.d.ts"]
+}

--- a/src/runtime.types.ts
+++ b/src/runtime.types.ts
@@ -30,7 +30,7 @@ export type StyledReactElement<
         : M[K] extends true | string | object
           ? K
           : never
-      : never]?: string;
+      : never]?: string | undefined;
   }
 >;
 
@@ -41,7 +41,7 @@ export type StyledProps<P, M extends StyledConfiguration<any>> = P & {
       : M[K] extends true | string | object
         ? K
         : never
-    : never]?: string;
+    : never]?: string | undefined;
 };
 
 export type Styled = <
@@ -64,7 +64,7 @@ type StyledComponent<
         : M[K] extends true | string | object
           ? K
           : never
-      : never]?: string;
+      : never]?: string | undefined;
   }
 >;
 

--- a/types.d.ts
+++ b/types.d.ts
@@ -1,4 +1,8 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
+// Every added prop is declared `| undefined` explicitly so the declarations
+// hold under `exactOptionalPropertyTypes`, where `?: string` forbids passing an
+// explicit `undefined` — which is what a conditional `className={x ? a : undefined}`
+// spreads, and what every optional prop in React Native's own types already allows.
 import type {
   ScrollViewProps,
   ScrollViewPropsAndroid,
@@ -10,64 +14,64 @@ import type {
 declare module "@react-native/virtualized-lists" {
   export interface VirtualizedListWithoutRenderItemProps<ItemT>
     extends ScrollViewProps {
-    ListFooterComponentClassName?: string;
-    ListHeaderComponentClassName?: string;
+    ListFooterComponentClassName?: string | undefined;
+    ListHeaderComponentClassName?: string | undefined;
   }
 }
 
 declare module "react-native" {
   interface ButtonProps {
-    className?: string;
+    className?: string | undefined;
   }
   interface ScrollViewProps
     extends ViewProps,
       ScrollViewPropsIOS,
       ScrollViewPropsAndroid,
       Touchable {
-    contentContainerClassName?: string;
-    indicatorClassName?: string;
+    contentContainerClassName?: string | undefined;
+    indicatorClassName?: string | undefined;
   }
   interface FlatListProps<ItemT> extends VirtualizedListProps<ItemT> {
-    columnWrapperClassName?: string;
+    columnWrapperClassName?: string | undefined;
   }
   interface ImageBackgroundProps extends ImagePropsBase {
-    imageClassName?: string;
+    imageClassName?: string | undefined;
   }
   interface ImagePropsBase {
-    className?: string;
-    cssInterop?: boolean;
+    className?: string | undefined;
+    cssInterop?: boolean | undefined;
   }
   interface ViewProps {
-    className?: string;
-    cssInterop?: boolean;
+    className?: string | undefined;
+    cssInterop?: boolean | undefined;
   }
   interface TextInputProps {
-    placeholderClassName?: string;
+    placeholderClassName?: string | undefined;
   }
   interface TextProps {
-    className?: string;
-    cssInterop?: boolean;
+    className?: string | undefined;
+    cssInterop?: boolean | undefined;
   }
   interface SwitchProps {
-    className?: string;
-    cssInterop?: boolean;
+    className?: string | undefined;
+    cssInterop?: boolean | undefined;
   }
   interface InputAccessoryViewProps {
-    className?: string;
-    cssInterop?: boolean;
+    className?: string | undefined;
+    cssInterop?: boolean | undefined;
   }
   interface TouchableWithoutFeedbackProps {
-    className?: string;
-    cssInterop?: boolean;
+    className?: string | undefined;
+    cssInterop?: boolean | undefined;
   }
   interface StatusBarProps {
-    className?: string;
-    cssInterop?: boolean;
+    className?: string | undefined;
+    cssInterop?: boolean | undefined;
   }
   interface KeyboardAvoidingViewProps extends ViewProps {
-    contentContainerClassName?: string;
+    contentContainerClassName?: string | undefined;
   }
   interface ModalBaseProps {
-    presentationClassName?: string;
+    presentationClassName?: string | undefined;
   }
 }


### PR DESCRIPTION
## Problem

React Native declares its own optional props as `| undefined` — 698 of them, and none bare. The props this package augments them with are bare `?: string`. Under `exactOptionalPropertyTypes` those two forms are not the same, and the difference falls on the most ordinary thing a consumer writes:

```tsx
<View className={condition ? "p-4" : undefined} />
```

```
error TS2769: Type '{ className: string | undefined; }' is not assignable to type 'Readonly<ViewProps>'
  with 'exactOptionalPropertyTypes: true'. Consider adding 'undefined' to the types of the target's properties.
```

Eleven authoring patterns fail this way — the conditional above, a `string | undefined` variable, a spread bag, a wrapper forwarding its own optional `className`, and the same for `cssInterop`, `contentContainerClassName`, `indicatorClassName`, `placeholderClassName`. A consumer cannot fix any of it locally: declaration merging can add props but never re-declare the optionality of existing ones. The only escape is patching the package or writing `{...(cond ? {className: x} : {})}` at every call site.

## Fix

Every added prop takes `| undefined`, in both places the contract is expressed.

`types.d.ts` is the obvious one. `src/runtime.types.ts` is the one that is easy to miss: `StyledProps`, `StyledReactElement` and `StyledComponent` synthesise the same props through mapped types ending `]?: string`, so they re-narrow it. Without those three tokens the bug still reproduces on `react-native-css/components` and `styled()` — the imports the README documents.

There is one observable change beyond permissiveness, and it goes toward consistency rather than away: under the flag, `Required<ViewProps>['className']` previously stripped `undefined` while `Required<ViewProps>['style']` kept it. Now they agree.

## Tests

`src/__tests__/types/` is a two-file program — the fixture plus `types.d.ts` — compiled with `exactOptionalPropertyTypes` on, wired into `typecheck` as a second `tsc` invocation. `src/__tests__/babel/tsconfig.json` is the existing precedent for a nested tsconfig here, and the leading underscore keeps the fixture out of jest via the existing `testPathIgnorePatterns`.

It is mutation-proven: reverting `types.d.ts` turns the gate red with 15 errors while the root `typecheck` stays green. That gap is the reason the gate exists — with the flag off, the old and new declarations are the same type, so no fixture compiled by the current `typecheck` can tell them apart. I checked the alternative first: a `@ts-expect-error` fixture is worse than useless, because it passes only in the broken configuration and turns CI **red** once the types are fixed.

The gate deliberately does not cover `runtime.types.ts` — importing `StyledProps` pulls 22 source files into the program and surfaces nine pre-existing errors unrelated to this change. Enabling the flag repo-wide is a reasonable follow-up (22 errors across 13 files today) but a different PR.

`npm pack --dry-run` ships no `__tests__`; `yarn build` is unaffected, since bob's babel targets exclude `__tests__` and its typescript target reads only the root tsconfig. One caveat: `lefthook.yml`'s pre-commit runs bare `yarn tsc`, so the gate runs in CI but not on a local commit.

Full suite, typecheck and lint measured against a pristine-`main` baseline on the same machine — no new failures.

## Notes

- `example/example-env.d.ts` is left alone deliberately. It is a generated duplicate, already divergent from `types.d.ts` on `main`, and referenced by nothing.
- #416 already declares its new props in this form, so landing this first keeps `types.d.ts` internally consistent.
- `CONTRIBUTING.md` asks that API changes start as an issue. Published types are API, so tell me if you would rather I open one — I led with the compile evidence because the change is small and the failure is mechanical.



---

**Scope note.** This sweep covers every prop declared in `types.d.ts` as of this branch. #416 adds
a `react-native-gesture-handler` module augmentation to the same file; its two props are already
declared `| undefined`, so the invariant holds across both, but the two PRs touch overlapping
lines and whichever lands second needs a rebase.
