### PR TITLE
fix: emit native injection code as CommonJS

### DIFF
--- a/src/__tests__/metro/injection-code.test.ts
+++ b/src/__tests__/metro/injection-code.test.ts
@@ -1,0 +1,29 @@
+import { Script } from "node:vm";
+
+import { getNativeInjectionCode } from "../../metro/injection-code";
+
+describe("getNativeInjectionCode", () => {
+  test("emits code that can execute in script mode", () => {
+    const inject = jest.fn();
+    const requireModule = jest.fn((specifier: string) => {
+      if (specifier === "react-native-css/native-internal") {
+        return { StyleCollection: { inject } };
+      }
+      return {};
+    });
+    const code = getNativeInjectionCode(
+      ["./styles.css"],
+      [{ s: [] }],
+    ).toString();
+
+    const script = new Script(code);
+    script.runInNewContext({ require: requireModule });
+
+    expect(requireModule).toHaveBeenNthCalledWith(
+      1,
+      "react-native-css/native-internal",
+    );
+    expect(requireModule).toHaveBeenNthCalledWith(2, "./styles.css");
+    expect(inject).toHaveBeenCalledWith({ s: [] });
+  });
+});

--- a/src/metro/injection-code.ts
+++ b/src/metro/injection-code.ts
@@ -21,7 +21,7 @@ export function getNativeInjectionCode(
   values: unknown[],
 ) {
   const importStatements = cssFilePaths
-    .map((filePath) => `import "${filePath}";`)
+    .map((filePath) => `require("${filePath}");`)
     .join("\n");
 
   const contents = values
@@ -29,6 +29,6 @@ export function getNativeInjectionCode(
     .join("\n");
 
   return Buffer.from(
-    `import { StyleCollection } from "react-native-css/native-internal";\n${importStatements}\n${contents};export {};`,
+    `const { StyleCollection } = require("react-native-css/native-internal");\n${importStatements}\n${contents}`,
   );
 }


### PR DESCRIPTION
## Summary

- emit native injection code with CommonJS `require()` calls
- preserve CSS side-effect loading and `StyleCollection.inject` behavior
- add a regression that parses and executes the generated source in script mode

The synthetic module previously retained raw `import` / `export` syntax, which reaches Hermes unchanged when Expo's optimize-graph tree shaking is enabled.

## Validation

- focused regression: 1 test passed
- full test suite: 56 suites passed (4 skipped), 1,052 tests passed (21 skipped)
- `yarn lint`
- `yarn typecheck`
- `yarn build`
- `git diff --check`

The exact Expo optimize-graph + Hermes export was not rerun locally; the regression directly covers the script-mode parse failure and the required module/injection behavior.

Closes #414.

AI assistance was used to inspect the issue, implement the focused change, and run validation. I reviewed the complete diff.