### PR TITLE
fix(types): type CSS custom properties against what both platforms honour

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,26 +214,28 @@ It is preferable that all CSS variables are set via CSS. If you need values to c
 }
 ```
 
-As a last resort, you can use `VariableContext` to dynamically set CSS variables in JavaScript
+As a last resort, you can use `VariableContextProvider` to dynamically set CSS variables in JavaScript
 
 ```ts
-import { VariableContext } from 'react-native-css';
+import { VariableContextProvider } from 'react-native-css';
 
 export default function App() {
   return (
-    <VariableContext values={{ "--my-color": "red" }}>
+    <VariableContextProvider value={{ "--my-color": "red" }}>
       <Text className="my-color-text">
         Hello, world!
       </Text>
-    </VariableContext>
+    </VariableContextProvider>
   )
 }
 ```
 
-This API only allows for setting CSS variables as primitive values. For more complex styles, you will need to use a helper CSS class.
+A custom property holds a token stream on web and a structured value on native, so this API accepts the values both platforms honour: a string, a number, a boolean, or an array of those (the `CustomPropertyValue` type).
+
+An array is a comma-separated CSS list — a `font-family` stack, a `transition-property` list. A value whose parts are separated by spaces, such as a `box-shadow`, is a single string. `undefined` leaves the property unset, so an ancestor's value inherits. Anything beyond that needs a helper CSS class.
 
 > [!IMPORTANT]  
-> By using `VariableContext` you may need to disable the `inlineVariable` optimization
+> By using `VariableContextProvider` you may need to disable the `inlineVariable` optimization
 
 ## Optimizations
 

--- a/src/__tests__/_custom-property-value.types.ts
+++ b/src/__tests__/_custom-property-value.types.ts
@@ -1,0 +1,85 @@
+/**
+ * Compile-time assertions for the value a CSS custom property can be given from
+ * JavaScript. `yarn typecheck` is the runner — there is nothing here to execute,
+ * which is why the filename is `_`-prefixed and jest skips it.
+ *
+ * The planes are reached as module types rather than imported, so the file stays
+ * type-only under `verbatimModuleSyntax`.
+ */
+import type { CustomPropertyValue } from "react-native-css";
+
+type RootApi = typeof import("react-native-css");
+type NativeApi = typeof import("react-native-css/native");
+type WebApi = typeof import("react-native-css/web");
+
+type Equal<X, Y> = [X] extends [Y] ? ([Y] extends [X] ? true : false) : false;
+type Expect<T extends true> = T;
+type Accepts<TValue, TTarget> = [TValue] extends [TTarget] ? true : false;
+
+type VarsParameter<TApi extends { vars: (variables: never) => unknown }> =
+  Parameters<TApi["vars"]>[0];
+type ProviderValue<
+  TApi extends { VariableContextProvider: (props: never) => unknown },
+> = Parameters<TApi["VariableContextProvider"]>[0]["value"];
+
+/**
+ * The parity invariant. `react-native-css` ships one set of declarations to both
+ * platforms — there is no `moduleSuffixes` or export condition that hands a
+ * consumer the native ones — so a value the shared entry accepts has to be a
+ * value both implementations honour. A future divergence fails here.
+ */
+export type Parity = [
+  Expect<Equal<VarsParameter<RootApi>, Record<string, CustomPropertyValue>>>,
+  Expect<Equal<VarsParameter<NativeApi>, VarsParameter<RootApi>>>,
+  Expect<Equal<VarsParameter<WebApi>, VarsParameter<RootApi>>>,
+  Expect<
+    Equal<ProviderValue<RootApi>, Record<`--${string}`, CustomPropertyValue>>
+  >,
+  Expect<Equal<ProviderValue<NativeApi>, ProviderValue<RootApi>>>,
+  Expect<Equal<ProviderValue<WebApi>, ProviderValue<RootApi>>>,
+];
+
+/**
+ * An array is a comma-separated CSS list, alongside the scalars a custom
+ * property can hold. `undefined` leaves the property unset so an ancestor's
+ * value inherits.
+ */
+export type Accepted = [
+  Expect<Accepts<string, CustomPropertyValue>>,
+  Expect<Accepts<number, CustomPropertyValue>>,
+  Expect<Accepts<boolean, CustomPropertyValue>>,
+  Expect<Accepts<undefined, CustomPropertyValue>>,
+  Expect<Accepts<string[], CustomPropertyValue>>,
+  Expect<Accepts<(string | number)[], CustomPropertyValue>>,
+  Expect<Accepts<(string | string[])[], CustomPropertyValue>>,
+];
+
+/**
+ * A `StyleDescriptor` is wider than a custom property's public value type. Each
+ * row fails if the type is widened past what both implementations serialise.
+ */
+export type Rejected = [
+  // `null` is not a CSS value — `undefined` is how a property is left unset.
+  Expect<Equal<Accepts<null, CustomPropertyValue>, false>>,
+  // An object has no custom-property serialisation.
+  Expect<Equal<Accepts<{ red: 1 }, CustomPropertyValue>, false>>,
+  // A StyleFunction is the compiler's own encoding of `var()`, `rgba()` and the
+  // rest. The web implementation has no way to serialise one.
+  Expect<
+    Equal<
+      Accepts<[Record<never, never>, "var", ["other"]], CustomPropertyValue>,
+      false
+    >
+  >,
+  // The compiler's whole descriptor union — what the native runtime resolves
+  // internally — is wider than what a caller may hand in.
+  Expect<
+    Equal<
+      Accepts<
+        import("react-native-css/compiler").StyleDescriptor,
+        CustomPropertyValue
+      >,
+      false
+    >
+  >,
+];

--- a/src/__tests__/native/vars.test.tsx
+++ b/src/__tests__/native/vars.test.tsx
@@ -36,3 +36,42 @@ test("vars", () => {
     color: "blue",
   });
 });
+
+test("vars: an array is a list the declaration consumes", () => {
+  registerCSS(`.my-class { font-variant-caps: var(--font-variant); }`);
+
+  render(
+    <View
+      testID={testID}
+      className="my-class"
+      style={vars({ "--font-variant": ["small-caps"] })}
+    />,
+  );
+
+  // `fontVariant` is one of the React Native style properties that takes an
+  // array, so the list has to survive the variable pipeline as a list.
+  expect(screen.getByTestId(testID).props.style).toStrictEqual({
+    fontVariant: ["small-caps"],
+  });
+});
+
+test("vars: undefined leaves the property unset", () => {
+  registerCSS(`
+    .my-class { color: var(--color); }
+    .green { --color: green; }
+  `);
+
+  render(
+    <View
+      testID={testID}
+      className="my-class green"
+      style={vars({ color: undefined })}
+    />,
+  );
+
+  // The class still sets `--color`, so leaving the inline value unset lets it
+  // through rather than blanking the property.
+  expect(screen.getByTestId(testID).props.style).toStrictEqual({
+    color: "#008000",
+  });
+});

--- a/src/__tests__/web/variables.test.tsx
+++ b/src/__tests__/web/variables.test.tsx
@@ -1,0 +1,56 @@
+import { View } from "react-native";
+
+import { render, screen } from "@testing-library/react-native";
+
+import { VariableContextProvider } from "../../web/api";
+
+const testID = "react-native-css";
+
+/** The custom properties the provider wrote onto its host element's style. */
+const customProperties = (
+  value: Parameters<typeof VariableContextProvider>[0]["value"],
+): unknown => {
+  render(
+    <VariableContextProvider value={value}>
+      <View testID={testID} />
+    </VariableContextProvider>,
+  );
+
+  return screen.root.props.style;
+};
+
+test("an array is a comma-separated CSS list", () => {
+  expect(customProperties({ "--font-stack": ["Inter", "Helvetica"] })).toEqual({
+    "display": "contents",
+    "--font-stack": "Inter,Helvetica",
+  });
+});
+
+test("a nested array flattens into the same list", () => {
+  expect(customProperties({ "--list": [1, ["a", true]] })).toEqual({
+    "display": "contents",
+    "--list": "1,a,true",
+  });
+});
+
+test("undefined leaves the property unset", () => {
+  expect(customProperties({ "--set": "red", "--unset": undefined })).toEqual({
+    "display": "contents",
+    "--set": "red",
+  });
+});
+
+test("an undefined member drops out of the list", () => {
+  expect(customProperties({ "--list": ["a", undefined, "b"] })).toEqual({
+    "display": "contents",
+    "--list": "a,b",
+  });
+});
+
+test("scalars serialise to their token form", () => {
+  expect(customProperties({ "--number": 1, "--boolean": true })).toEqual({
+    "display": "contents",
+    "--number": "1",
+    "--boolean": "true",
+  });
+});

--- a/src/native-internal/variables.tsx
+++ b/src/native-internal/variables.tsx
@@ -5,9 +5,8 @@ import {
   type PropsWithChildren,
 } from "react";
 
-import type { StyleDescriptor } from "react-native-css/compiler";
-
 import { VAR_SYMBOL, type VariableContextValue } from "../native/reactivity";
+import type { CustomPropertyValue } from "../runtime.types";
 
 globalThis.__react_native_css_variable_context ??=
   createContext<VariableContextValue>({
@@ -17,7 +16,9 @@ globalThis.__react_native_css_variable_context ??=
 export const VariableContext = globalThis.__react_native_css_variable_context;
 
 export function VariableContextProvider(
-  props: PropsWithChildren<{ value: Record<`--${string}`, StyleDescriptor> }>,
+  props: PropsWithChildren<{
+    value: Record<`--${string}`, CustomPropertyValue>;
+  }>,
 ) {
   const inheritedVariables = useContext(VariableContext);
 

--- a/src/native/api.tsx
+++ b/src/native/api.tsx
@@ -2,11 +2,11 @@
 import { useContext, useState, type ComponentType } from "react";
 import { Appearance } from "react-native";
 
-import type { StyleDescriptor } from "react-native-css/compiler";
 import { VariableContext } from "react-native-css/native-internal";
 
 import type {
   ColorScheme,
+  CustomPropertyValue,
   Props,
   ReactComponent,
   StyledConfiguration,
@@ -114,7 +114,7 @@ export function useNativeVariable(name: string) {
 /**
  * @deprecated Use `<VariableContextProvider />` instead.
  */
-export function vars(variables: Record<string, StyleDescriptor>) {
+export function vars(variables: Record<string, CustomPropertyValue>) {
   return Object.assign(
     { [VAR_SYMBOL]: "inline" },
     Object.fromEntries(

--- a/src/runtime.types.ts
+++ b/src/runtime.types.ts
@@ -136,6 +136,33 @@ export type InlineStyle =
   | (Record<string, unknown> | undefined | null)[]
   | (() => unknown);
 
+/*******************************    Variables    ******************************/
+
+/**
+ * A value a CSS custom property can be given from JavaScript, via `vars()` or
+ * `<VariableContextProvider />`.
+ *
+ * Both platforms are written against this one type. A custom property holds a
+ * token stream on web and a structured value on native, so the type is the set
+ * of values both can honour:
+ *
+ * - An array is a comma-separated CSS list — a `font-family` stack, a
+ *   `transition-property` list. A value whose parts are separated by spaces (a
+ *   `box-shadow`, a `transform`) is a single string.
+ * - `undefined` leaves the property unset, so an ancestor's value inherits.
+ *
+ * A `StyleDescriptor` is wider than this: it also covers the `StyleFunction`
+ * tuples the compiler emits for `var()`, `rgba()` and friends. Those are an
+ * internal encoding of the native runtime and have no web serialisation, so
+ * they are not part of the public API.
+ */
+export type CustomPropertyValue =
+  | string
+  | number
+  | boolean
+  | undefined
+  | CustomPropertyValue[];
+
 /*********************************    Misc    *********************************/
 
 export type Props = Record<string, any> | undefined | null;

--- a/src/web/api.tsx
+++ b/src/web/api.tsx
@@ -15,7 +15,7 @@ import type {
   StyledProps,
 } from "react-native-css";
 
-import type { ReactComponent } from "../runtime.types";
+import type { CustomPropertyValue, ReactComponent } from "../runtime.types";
 import { assignStyle } from "./assign-style";
 
 const defaultMapping: StyledConfiguration<ComponentType<{ style: unknown }>> = {
@@ -78,33 +78,57 @@ export const colorScheme: ColorScheme = {
 };
 
 /**
- * @deprecated Use `<VariableContextProvider />` instead.
+ * Serialises a custom property into the token stream CSS stores it as. An array
+ * is a comma-separated list; an `undefined` member drops out of that list, and
+ * an `undefined` value leaves the property unset altogether.
  */
-export function vars(variables: Record<string, string | number>) {
-  const $variables: Record<string, string> = {};
+function serializeCustomProperty(
+  value: CustomPropertyValue,
+): string | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  if (Array.isArray(value)) {
+    return value
+      .map((member) => serializeCustomProperty(member))
+      .filter((member) => member !== undefined)
+      .join(",");
+  }
+
+  return String(value);
+}
+
+function toCustomProperties(variables: Record<string, CustomPropertyValue>) {
+  const properties: Record<string, string> = {};
 
   for (const [key, value] of Object.entries(variables)) {
-    if (key.startsWith("--")) {
-      $variables[key] = value.toString();
-    } else {
-      $variables[`--${key}`] = value.toString();
+    const serialized = serializeCustomProperty(value);
+
+    if (serialized !== undefined) {
+      properties[key.startsWith("--") ? key : `--${key}`] = serialized;
     }
   }
-  return $variables;
+
+  return properties;
+}
+
+/**
+ * @deprecated Use `<VariableContextProvider />` instead.
+ */
+export function vars(variables: Record<string, CustomPropertyValue>) {
+  return toCustomProperties(variables);
 }
 
 export function VariableContextProvider(
-  props: PropsWithChildren<{ value: Record<`--${string}`, string | number> }>,
+  props: PropsWithChildren<{
+    value: Record<`--${string}`, CustomPropertyValue>;
+  }>,
 ) {
   const style = useMemo(() => {
     return {
       display: "contents",
-      ...Object.fromEntries(
-        Object.entries(props.value).map(([key, value]) => [
-          key.startsWith("--") ? key : `--${key}`,
-          value,
-        ]),
-      ),
+      ...toCustomProperties(props.value),
     };
   }, [props.value]);
 


### PR DESCRIPTION
## Problem

`vars()` and `<VariableContextProvider />` are declared twice — once in `src/web/api.tsx` as `Record<string, string | number>`, once in `src/native/api.tsx` and `src/native-internal/variables.tsx` as `Record<string, StyleDescriptor>`. Neither is the set of values both implementations honour, and **a consumer only ever sees the web one.**

### One set of declarations reaches both platforms

The `.` export has no `react-native` condition. Its `types` in both the `import` and `require` branches point at `dist/typescript/…/src/index.d.ts`, which re-exports `./runtime`, which re-exports `./web`. `dist/typescript/…/src/runtime.native.d.ts` is built and shipped, but nothing selects it — reaching a `.native` declaration needs `moduleSuffixes`, and neither Expo nor React Native sets it.

The clearest demonstration is inside this repo. `src/__tests__/native/vars.test.tsx` is a native test that imports `vars` from `react-native-css/runtime`, and jest resolves that to the **native** runtime while `tsc` resolves it to the **web** declarations. On `main`, with this branch's two new cases in that file, they **pass under jest and fail under `tsc`**:

```
src/__tests__/native/vars.test.tsx(47,21): error TS2322: Type 'string[]' is not assignable to type 'string | number'.
src/__tests__/native/vars.test.tsx(68,21): error TS2322: Type 'undefined' is not assignable to type 'string | number'.
```

Same file, same import, two answers. That is the whole bug in one artifact: the native runtime resolves both calls end to end, and the type a consumer is handed says they are errors.

### The web declaration is too narrow

`vars({ "--font-stack": ["Inter", "Helvetica"] })` and `vars({ "--color": undefined })` are type errors on the shared entry, and the only way through is a cast. Both work on native.

### The native declaration is too wide for web to serialise

`StyleDescriptor` admits `undefined` and the `StyleFunction` tuples the compiler emits for `var()` and `rgba()`. Measured against `main`'s web `vars()`:

| value | web `vars()` on `main` |
| --- | --- |
| `undefined` | **throws** `Cannot read properties of undefined (reading 'toString')` |
| `null` | **throws** `Cannot read properties of null (reading 'toString')` |
| `[{}, "var", ["y"]]` (a `StyleFunction`) | `{"--x": "[object Object],var,y"}` |

A consumer importing from `react-native-css/native` is handed a type that permits all three.

### `VariableContextProvider` never serialises

It spreads the raw JS values into the `style` object of its `<div>`. Measured on `main`:

| `value` | style object on `main` | this branch |
| --- | --- | --- |
| `{ "--font-stack": ["Inter", "Helvetica"] }` | `--font-stack` is an `Array` | `"Inter,Helvetica"` |
| `{ "--list": [1, ["a", true]] }` | `--list` is a nested `Array` | `"1,a,true"` |
| `{ "--list": ["a", undefined, "b"] }` | `--list` is an `Array` with a hole | `"a,b"` |
| `{ "--number": 1, "--boolean": true }` | `1` and `true`, unstringified | `"1"` and `"true"` |

### The README documents an API that is not exported

It shows `import { VariableContext } from 'react-native-css'` and `<VariableContext values={…}>`. `src/web/api.tsx` — which is what `react-native-css` resolves to for types — exports `VariableContextProvider` and does not export `VariableContext` at all, and the prop is `value`, not `values`.

## Fix

One `CustomPropertyValue` type in `src/runtime.types.ts`, and both planes written against it:

```ts
export type CustomPropertyValue =
  | string | number | boolean | undefined | CustomPropertyValue[];
```

It is the set of values both implementations honour. An array is a **comma-separated CSS list** — a `font-family` stack, a `transition-property` list — which is what the web serialisation already produced for a flat array and what the native resolver keeps structured until the declaration reading `var()` consumes it. A value whose parts are space-separated (a `box-shadow`, a `transform`) is a single string. `undefined` leaves the property unset on both, so an ancestor's value inherits.

On web, `serializeCustomProperty` / `toCustomProperties` do the serialisation explicitly and are shared by `vars()` and the provider, which previously had two different behaviours for the same input.

This **narrows** the native declarations by `StyleFunction` and `null`. Those are the compiler's internal encoding with no web serialisation, so they do not belong in a type that ships to both platforms — but it is the one part of this that could break someone, and it is the part to push back on if you disagree.

The README section is corrected to the component and prop that exist, and states the value contract.

## Which plane

**Both**, plus the shared type — that is the point of the change rather than an accident of it. `src/runtime.types.ts` holds the type; `src/web/api.tsx` gains the serialisation; `src/native/api.tsx` and `src/native-internal/variables.tsx` narrow their signatures with no runtime change. The compiler is not involved.

## Tests

7 runtime tests plus a type fixture. **4 of the 7 fail on `main`**, and the split is the finding:

- `src/__tests__/web/variables.test.tsx` — 5 new tests over `VariableContextProvider`. **4 fail on `main`** (the four rows in the table above). The fifth, `undefined leaves the property unset`, passes on `main` because an `undefined` in the style object reads the same as an absent key.
- `src/__tests__/native/vars.test.tsx` — 2 new tests, an array reaching `fontVariant` as an array and an `undefined` letting a class's value through. **Both pass on `main`.** That is not a gap — it is the claim: native already honoured these values, and the type said otherwise. They are what makes the widened type honest rather than optimistic, and they are the runtime half of the `tsc`-vs-jest divergence above.
- `src/__tests__/_custom-property-value.types.ts` — the compile-time half, run by the existing `yarn typecheck` with no new tsconfig. Jest skips it via the existing `testPathIgnorePatterns: [".*/_[a-zA-Z]"]`. It asserts the parity invariant (`vars` and the provider have the same parameter on `react-native-css`, `/native` and `/web`), what the type accepts, and what it must keep rejecting — `null`, a plain object, a `StyleFunction`, and `StyleDescriptor` as a whole.

It is mutation-proven: dropped onto `main` unchanged, `yarn typecheck` fails with **14 errors — 7 from the fixture** (starting with `Module '"react-native-css"' has no exported member 'CustomPropertyValue'` and then six `Type 'false' does not satisfy the constraint 'true'`), plus 2 from the native test file and 5 from the web one. On this branch `yarn typecheck` exits 0.

Full suite, typecheck and lint measured against a pristine-`main` baseline on the same machine, same worktree layout — no new failures. `main` is 1048 passed / 3 failed (the two `src/__tests__/babel/*` suites, which fail identically at every ref on Windows); this branch is 1055 passed / 3 failed. `yarn typecheck` and `yarn lint` exit 0 on both.

## KNOWN LIMITS

**The web tests assert the style object, not what a browser paints.** React DOM coerces a custom property through `style.setProperty`, so a number and a flat array already reach CSS as the right token stream on `main`. The differences that survive into a real browser are narrower than the table suggests, and there are two. A **boolean** is cleared rather than set — react-dom 19.1.0's `setValueForStyle` branches `null == value || "boolean" === typeof value || "" === value` into `style.setProperty(styleName, "")`, so `true` becomes nothing on `main` where this branch makes it `"true"`. And an **`undefined` member inside an array** stringifies to an empty item — `["a", undefined, "b"].toString()` is `"a,,b"`, not `"a,b"`. The rest of the value of serialising explicitly is that the two planes now agree by construction instead of by the DOM's coercion happening to match.

**`null` is still accepted at runtime on web, and now stringifies instead of throwing.** It is outside `CustomPropertyValue`, so a typed consumer cannot reach it, but an untyped one gets `"--x": "null"` where `main` threw. I would rather that than a throw; say so if you would rather it dropped like `undefined`.

**This does not make the native declarations reachable.** It makes the one declaration a consumer actually gets correct for both platforms. Shipping genuinely per-platform types would mean a `react-native` export condition on `.`, which is a much larger change and a separate conversation.

---

**Overlaps with open PRs.** Measured with `git merge-tree` against every open PR head — no hard conflicts, but three files are shared:

- **#418** (`rncss/types-optional-undefined`) — `src/runtime.types.ts`. It rewrites the mapped types further down the file; this adds `CustomPropertyValue` above them. They auto-merge, and they agree: `CustomPropertyValue` already includes `undefined`.
- **#415** (`fix/color-scheme-appearance-projection`) — `src/native/api.tsx`, different function, auto-merges.
- **#344** also touches `src/runtime.types.ts`; **#411**, **#397** and **#406** also touch `README.md`. All auto-merge today.

Whichever lands second needs at most a trivial rebase.
