### PR TITLE
fix: compile on every react-native in the peer range, not just 0.81

### DIFF
--- a/package.json
+++ b/package.json
@@ -215,6 +215,7 @@
     "@eslint/js": "^10.0.1",
     "@expo/metro-config": "~54.0.5",
     "@ianvs/prettier-plugin-sort-imports": "^4.4.2",
+    "@react-native/jest-preset": "^0.85.0",
     "@release-it/conventional-changelog": "10.0.1",
     "@tailwindcss/postcss": "^4.1.12",
     "@testing-library/react-native": "^13.3.3",

--- a/src/__tests__/native/color-scheme.test.tsx
+++ b/src/__tests__/native/color-scheme.test.tsx
@@ -1,0 +1,105 @@
+import {
+  Appearance,
+  type ColorSchemeName as ReactNativeColorSchemeName,
+} from "react-native";
+
+import { act, render, screen } from "@testing-library/react-native";
+import { View } from "react-native-css/components/View";
+import { registerCSS, testID } from "react-native-css/jest";
+import { colorScheme } from "react-native-css/runtime";
+import type { ColorSchemeName } from "react-native-css/runtime.types";
+
+import { setAppearanceColorScheme } from "../../color-scheme";
+
+const mockSetColorScheme = jest.fn();
+
+// `Appearance` reads its native module lazily, so mocking the module is enough to make
+// the writes observable. Without it `TurboModuleRegistry.get('Appearance')` is null
+// under jest and every `setColorScheme` is a silent no-op.
+jest.mock("react-native/Libraries/Utilities/NativeAppearance", () => ({
+  __esModule: true,
+  default: {
+    setColorScheme: (scheme: string) => {
+      mockSetColorScheme(scheme);
+    },
+    // `getColorScheme` feeds react-native's own post-write bookkeeping, which asserts
+    // the value is a resolved scheme or absent.
+    getColorScheme: () => undefined,
+    addListener: () => undefined,
+    removeListeners: () => undefined,
+  },
+}));
+
+/*******************************  Compile plane  ******************************/
+
+type Assert<T extends true> = T;
+type Covers<Actual, Accepted> = [Actual] extends [Accepted] ? true : false;
+
+type AppearanceChangeColorScheme = Parameters<
+  Parameters<typeof Appearance.addChangeListener>[0]
+>[0]["colorScheme"];
+
+/**
+ * `ColorSchemeName` is react-native-css's own union rather than react-native's, because
+ * react-native's changes shape inside this package's peer range: up to 0.85 "follow the
+ * system" is `null | undefined`, from 0.86 it is `"unspecified"`.
+ *
+ * These aliases are read off the installed react-native rather than restating either
+ * spelling, so `yarn typecheck` fails at whichever end of the range the checkout is on
+ * the moment the package stops covering a value react-native hands it.
+ */
+export type CoversReactNativeUnion = Assert<
+  Covers<ReactNativeColorSchemeName, ColorSchemeName>
+>;
+export type CoversAppearanceRead = Assert<
+  Covers<ReturnType<typeof Appearance.getColorScheme>, ColorSchemeName>
+>;
+export type CoversAppearanceEvent = Assert<
+  Covers<AppearanceChangeColorScheme, ColorSchemeName>
+>;
+
+/*******************************  Runtime plane  ******************************/
+
+beforeEach(() => {
+  mockSetColorScheme.mockClear();
+});
+
+test.each([
+  ["light", "light"],
+  ["dark", "dark"],
+  ["unspecified", "unspecified"],
+  [null, "unspecified"],
+  [undefined, "unspecified"],
+] satisfies [ColorSchemeName, string][])(
+  "setAppearanceColorScheme(%p) reaches the native module as %p",
+  (value, expected) => {
+    setAppearanceColorScheme(value);
+
+    expect(mockSetColorScheme).toHaveBeenCalledTimes(1);
+    expect(mockSetColorScheme).toHaveBeenCalledWith(expected);
+  },
+);
+
+test("prefers-color-scheme follows the scheme and releases on 'unspecified'", () => {
+  registerCSS(`
+.my-class { color: blue; }
+
+@media (prefers-color-scheme: dark) {
+  .my-class { color: red; }
+}`);
+
+  render(<View testID={testID} className="my-class" />);
+  const component = screen.getByTestId(testID);
+
+  expect(component.props.style).toStrictEqual({ color: "#00f" });
+
+  act(() => {
+    colorScheme.set("dark");
+  });
+  expect(component.props.style).toStrictEqual({ color: "#f00" });
+
+  act(() => {
+    colorScheme.set("unspecified");
+  });
+  expect(component.props.style).toStrictEqual({ color: "#00f" });
+});

--- a/src/__tests__/native/components.test.tsx
+++ b/src/__tests__/native/components.test.tsx
@@ -1,5 +1,6 @@
 import {
   Button as RNButton,
+  ScrollView as RNScrollView,
   TextInput as RNTextInput,
   type ButtonProps,
   type TextInputProps,
@@ -11,6 +12,7 @@ import { TextInput } from "react-native-css/components/TextInput";
 import { registerCSS, testID } from "react-native-css/jest";
 import { useCssElement } from "react-native-css/native";
 import type {
+  ComponentPropsDotNotation,
   StyledConfiguration,
   StyledProps,
 } from "react-native-css/runtime.types";
@@ -113,4 +115,23 @@ test("nativeStyleMapping with boolean true on custom component", () => {
 
   expect(component.props.textAlign).toBe("right");
   expect(component.props.style).not.toHaveProperty("textAlign");
+});
+
+test("a prop holding a component instance is a dot-notation leaf", () => {
+  // `ScrollViewProps.scrollViewRef` is a `RefObject<ScrollView>`, and `ScrollView`
+  // carries `ScrollViewProps` again, so the prop graph is cyclic. Enumerating it
+  // produces paths that can never be a mapping target, and enough of them that
+  // `StyledConfiguration<typeof ScrollView>`, and every component built on it, stops
+  // compiling with TS2590 on react-native >=0.86.
+  const reachable: ComponentPropsDotNotation<typeof RNScrollView>[] = [
+    "scrollViewRef",
+    "scrollViewRef.current",
+  ];
+
+  // @ts-expect-error - the instance behind the ref is a leaf, so its props are not paths
+  const throughInstance: ComponentPropsDotNotation<typeof RNScrollView> =
+    "scrollViewRef.current.props.style";
+
+  expect(reachable).toHaveLength(2);
+  expect(throughInstance).toBe("scrollViewRef.current.props.style");
 });

--- a/src/__tests__/native/components.test.tsx
+++ b/src/__tests__/native/components.test.tsx
@@ -122,7 +122,7 @@ test("a prop holding a component instance is a dot-notation leaf", () => {
   // carries `ScrollViewProps` again, so the prop graph is cyclic. Enumerating it
   // produces paths that can never be a mapping target, and enough of them that
   // `StyledConfiguration<typeof ScrollView>`, and every component built on it, stops
-  // compiling with TS2590 on react-native >=0.86.
+  // compiling with TS2590 on react-native >=0.83.
   const reachable: ComponentPropsDotNotation<typeof RNScrollView>[] = [
     "scrollViewRef",
     "scrollViewRef.current",

--- a/src/color-scheme.ts
+++ b/src/color-scheme.ts
@@ -4,15 +4,15 @@ import type { ColorSchemeName } from "./runtime.types";
 
 /**
  * `Appearance.setColorScheme` is not declared the same way across the supported
- * `react-native` range. Up to 0.85 it takes `"light" | "dark" | null | undefined`;
- * from 0.86 it takes `"light" | "dark" | "unspecified"` and rejects `null`. The two
+ * `react-native` range. On 0.81 it takes `"light" | "dark" | null | undefined`; from
+ * 0.82 it takes `"light" | "dark" | "unspecified"` and rejects `null`. The two
  * parameter types overlap only on `"light" | "dark"`, so no single call can name the
  * "follow the system" value and type-check on both.
  *
- * The runtime is not split the same way: every version in the range hands
- * `"unspecified"` to the native module for that state, because 0.85 and earlier map
- * `null` to it on the way in. So only the declaration has to be restated, and only for
- * the one value the versions disagree about.
+ * `"unspecified"` is the value that is right at runtime on every version: 0.82 and
+ * later hand the argument straight to the native module, and 0.81 maps `null` to
+ * `"unspecified"` before doing the same. So only the declaration has to be restated,
+ * and only for the one value the versions disagree about.
  */
 interface AppearanceColorSchemeReset {
   setColorScheme: (colorScheme: "unspecified") => void;

--- a/src/color-scheme.ts
+++ b/src/color-scheme.ts
@@ -1,0 +1,35 @@
+import { Appearance } from "react-native";
+
+import type { ColorSchemeName } from "./runtime.types";
+
+/**
+ * `Appearance.setColorScheme` is not declared the same way across the supported
+ * `react-native` range. Up to 0.85 it takes `"light" | "dark" | null | undefined`;
+ * from 0.86 it takes `"light" | "dark" | "unspecified"` and rejects `null`. The two
+ * parameter types overlap only on `"light" | "dark"`, so no single call can name the
+ * "follow the system" value and type-check on both.
+ *
+ * The runtime is not split the same way: every version in the range hands
+ * `"unspecified"` to the native module for that state, because 0.85 and earlier map
+ * `null` to it on the way in. So only the declaration has to be restated, and only for
+ * the one value the versions disagree about.
+ */
+interface AppearanceColorSchemeReset {
+  setColorScheme: (colorScheme: "unspecified") => void;
+}
+
+/**
+ * Writes a color scheme to `Appearance` in a way that compiles and runs on every
+ * `react-native` this package supports.
+ */
+export function setAppearanceColorScheme(value: ColorSchemeName): void {
+  if (value === "light" || value === "dark") {
+    // Declared identically by every version in the range.
+    Appearance.setColorScheme(value);
+    return;
+  }
+
+  (Appearance as unknown as AppearanceColorSchemeReset).setColorScheme(
+    "unspecified",
+  );
+}

--- a/src/jest/index.ts
+++ b/src/jest/index.ts
@@ -1,10 +1,11 @@
-import { Appearance, Dimensions } from "react-native";
+import { Dimensions } from "react-native";
 
 import { inspect } from "node:util";
 
 import { compile, type CompilerOptions } from "react-native-css/compiler";
 import { StyleCollection } from "react-native-css/native";
 
+import { setAppearanceColorScheme } from "../color-scheme";
 import { colorScheme, dimensions } from "../native/reactivity";
 
 declare global {
@@ -21,7 +22,7 @@ export const testID = "react-native-css";
 beforeEach(() => {
   StyleCollection.styles.clear();
   dimensions.set(Dimensions.get("window"));
-  Appearance.setColorScheme(null);
+  setAppearanceColorScheme(null);
   colorScheme.set(null);
 });
 

--- a/src/native/reactivity.ts
+++ b/src/native/reactivity.ts
@@ -1,13 +1,10 @@
 /* eslint-disable */
 import { createContext } from "react";
-import {
-  Appearance,
-  Dimensions,
-  type ColorSchemeName,
-  type LayoutRectangle,
-} from "react-native";
+import { Appearance, Dimensions, type LayoutRectangle } from "react-native";
 
 import type { StyleDescriptor } from "react-native-css/compiler";
+
+import type { ColorSchemeName } from "../runtime.types";
 
 export type Effect = {
   observers: Set<Effect>;

--- a/src/runtime.types.ts
+++ b/src/runtime.types.ts
@@ -144,8 +144,8 @@ export type RNStyle = ViewStyle & TextStyle & ImageStyle;
  * `react-native` range.
  *
  * This deliberately does not reuse `react-native`'s own `ColorSchemeName`: that type
- * is not stable across the `react-native` peer range. Up to 0.85 it is
- * `"light" | "dark" | null | undefined`; from 0.86 it is
+ * is not stable across the `react-native` peer range. On 0.81 it is
+ * `"light" | "dark" | null | undefined`; from 0.82 it is
  * `"light" | "dark" | "unspecified"`. Owning the union keeps `colorScheme` one API
  * across the whole range, and accepts whichever spelling the installed version emits.
  */

--- a/src/runtime.types.ts
+++ b/src/runtime.types.ts
@@ -8,12 +8,7 @@ import type {
   FunctionComponent,
   ReactElement,
 } from "react";
-import type {
-  ColorSchemeName,
-  ImageStyle,
-  TextStyle,
-  ViewStyle,
-} from "react-native";
+import type { ImageStyle, TextStyle, ViewStyle } from "react-native";
 
 import type { DotNotation, ResolveDotPath } from "react-native-css/utilities";
 
@@ -143,6 +138,23 @@ export type Callback = () => void;
 export type RNStyle = ViewStyle & TextStyle & ImageStyle;
 
 /********************************    Globals    ********************************/
+
+/**
+ * A color scheme, plus every spelling of "follow the system" in the supported
+ * `react-native` range.
+ *
+ * This deliberately does not reuse `react-native`'s own `ColorSchemeName`: that type
+ * is not stable across the `react-native` peer range. Up to 0.85 it is
+ * `"light" | "dark" | null | undefined`; from 0.86 it is
+ * `"light" | "dark" | "unspecified"`. Owning the union keeps `colorScheme` one API
+ * across the whole range, and accepts whichever spelling the installed version emits.
+ */
+export type ColorSchemeName =
+  | "light"
+  | "dark"
+  | "unspecified"
+  | null
+  | undefined;
 
 export interface ColorScheme {
   get: () => ColorSchemeName;

--- a/src/utilities/dot-notation.types.ts
+++ b/src/utilities/dot-notation.types.ts
@@ -1,4 +1,6 @@
 /* eslint-disable */
+import type { Component } from "react";
+
 // ---------- Base Utilities ----------
 
 type Falsy = undefined | null | false | "";
@@ -51,13 +53,22 @@ type ExtractStyleObject<T> = RemoveRegisteredStyle<
   RemoveFalsy<UnwrapRecursiveArray<T extends StyleProp<infer U> ? U : T>>
 >;
 
-// Check if something is a non-array plain object
+// Check if something is a non-array plain object.
+//
+// A class component instance is not one. It is reachable only through a ref, it holds
+// its own props, and those props hold refs again, so the prop graph is cyclic. Walking
+// it yields paths that can never be a mapping target, and the path set grows
+// exponentially with depth: `ScrollViewProps["scrollViewRef"]` alone contributes 4,654
+// such paths, which is enough to overflow TypeScript's union limit on react-native
+// >=0.86. Treating the instance as a leaf cuts the cycle where it starts.
 type IsPlainObject<T> = T extends object
   ? T extends Function
     ? false
     : T extends readonly any[]
       ? false
-      : true
+      : T extends Component<any, any>
+        ? false
+        : true
   : false;
 
 // ---------- Resolve Path Type Helpers ----------

--- a/src/utilities/dot-notation.types.ts
+++ b/src/utilities/dot-notation.types.ts
@@ -59,8 +59,9 @@ type ExtractStyleObject<T> = RemoveRegisteredStyle<
 // its own props, and those props hold refs again, so the prop graph is cyclic. Walking
 // it yields paths that can never be a mapping target, and the path set grows
 // exponentially with depth: `ScrollViewProps["scrollViewRef"]` alone contributes 4,654
-// such paths, which is enough to overflow TypeScript's union limit on react-native
-// >=0.86. Treating the instance as a leaf cuts the cycle where it starts.
+// such paths on react-native 0.81, and from 0.83 the host instance surface is wide
+// enough that building the union overflows TypeScript's limit. Treating the instance as
+// a leaf cuts the cycle where it starts.
 type IsPlainObject<T> = T extends object
   ? T extends Function
     ? false

--- a/src/web/api.tsx
+++ b/src/web/api.tsx
@@ -15,6 +15,7 @@ import type {
   StyledProps,
 } from "react-native-css";
 
+import { setAppearanceColorScheme } from "../color-scheme";
 import type { ReactComponent } from "../runtime.types";
 import { assignStyle } from "./assign-style";
 
@@ -73,7 +74,7 @@ export const colorScheme: ColorScheme = {
     return Appearance.getColorScheme();
   },
   set(name) {
-    Appearance.setColorScheme(name);
+    setAppearanceColorScheme(name);
   },
 };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -102,7 +102,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/code-frame@npm:^7.29.7":
+"@babel/code-frame@npm:^7.29.0, @babel/code-frame@npm:^7.29.7":
   version: 7.29.7
   resolution: "@babel/code-frame@npm:7.29.7"
   dependencies:
@@ -163,6 +163,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/generator@npm:^7.29.1, @babel/generator@npm:^7.29.8":
+  version: 7.29.8
+  resolution: "@babel/generator@npm:7.29.8"
+  dependencies:
+    "@babel/parser": "npm:^7.29.8"
+    "@babel/types": "npm:^7.29.8"
+    "@jridgewell/gen-mapping": "npm:^0.3.12"
+    "@jridgewell/trace-mapping": "npm:^0.3.28"
+    jsesc: "npm:^3.0.2"
+  checksum: 10c0/7b896696314a659652393b76d78276e236acd0f7fae40a9a1af7f01c76aeafc630dd0966aad6f9386d35d7c674a8e6e2d8e217c44d25fb11460e68afa9ba8441
+  languageName: node
+  linkType: hard
+
 "@babel/generator@npm:^7.29.7":
   version: 7.29.7
   resolution: "@babel/generator@npm:7.29.7"
@@ -194,7 +207,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helper-compilation-targets@npm:^7.27.1, @babel/helper-compilation-targets@npm:^7.27.2":
+"@babel/helper-compilation-targets@npm:^7.27.2":
   version: 7.27.2
   resolution: "@babel/helper-compilation-targets@npm:7.27.2"
   dependencies:
@@ -602,6 +615,17 @@ __metadata:
   bin:
     parser: ./bin/babel-parser.js
   checksum: 10c0/58b239a5b1477ac7ed7e29d86d675cc81075ca055424eba6485872626db2dc556ce63c45043e5a679cd925e999471dba8a3ed4864e7ab1dbf64306ab72c52707
+  languageName: node
+  linkType: hard
+
+"@babel/parser@npm:^7.29.0, @babel/parser@npm:^7.29.8":
+  version: 7.29.8
+  resolution: "@babel/parser@npm:7.29.8"
+  dependencies:
+    "@babel/types": "npm:^7.29.8"
+  bin:
+    parser: ./bin/babel-parser.js
+  checksum: 10c0/acc890c5e6a6dd40863a47b50bac111d7185ee6fbbe163ebe11d5214854ca2adb901462ad4d718a65090ef84bd2230e9e8ab45a2e0caccc685f1f57ab0bb1e28
   languageName: node
   linkType: hard
 
@@ -1018,7 +1042,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-arrow-functions@npm:^7.0.0-0, @babel/plugin-transform-arrow-functions@npm:^7.24.7":
+"@babel/plugin-transform-arrow-functions@npm:^7.0.0-0":
   version: 7.27.1
   resolution: "@babel/plugin-transform-arrow-functions@npm:7.27.1"
   dependencies:
@@ -1029,7 +1053,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-arrow-functions@npm:^7.29.7":
+"@babel/plugin-transform-arrow-functions@npm:^7.24.7, @babel/plugin-transform-arrow-functions@npm:^7.29.7":
   version: 7.29.7
   resolution: "@babel/plugin-transform-arrow-functions@npm:7.29.7"
   dependencies:
@@ -1205,19 +1229,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-computed-properties@npm:^7.24.7":
-  version: 7.27.1
-  resolution: "@babel/plugin-transform-computed-properties@npm:7.27.1"
-  dependencies:
-    "@babel/helper-plugin-utils": "npm:^7.27.1"
-    "@babel/template": "npm:^7.27.1"
-  peerDependencies:
-    "@babel/core": ^7.0.0-0
-  checksum: 10c0/e09a12f8c8ae0e6a6144c102956947b4ec05f6c844169121d0ec4529c2d30ad1dc59fee67736193b87a402f44552c888a519a680a31853bdb4d34788c28af3b0
-  languageName: node
-  linkType: hard
-
-"@babel/plugin-transform-computed-properties@npm:^7.29.7":
+"@babel/plugin-transform-computed-properties@npm:^7.24.7, @babel/plugin-transform-computed-properties@npm:^7.29.7":
   version: 7.29.7
   resolution: "@babel/plugin-transform-computed-properties@npm:7.29.7"
   dependencies:
@@ -1392,20 +1404,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-function-name@npm:^7.25.1":
-  version: 7.27.1
-  resolution: "@babel/plugin-transform-function-name@npm:7.27.1"
-  dependencies:
-    "@babel/helper-compilation-targets": "npm:^7.27.1"
-    "@babel/helper-plugin-utils": "npm:^7.27.1"
-    "@babel/traverse": "npm:^7.27.1"
-  peerDependencies:
-    "@babel/core": ^7.0.0-0
-  checksum: 10c0/5abdc7b5945fbd807269dcc6e76e52b69235056023b0b35d311e8f5dfd6c09d9f225839798998fc3b663f50cf701457ddb76517025a0d7a5474f3fe56e567a4c
-  languageName: node
-  linkType: hard
-
-"@babel/plugin-transform-function-name@npm:^7.29.7":
+"@babel/plugin-transform-function-name@npm:^7.25.1, @babel/plugin-transform-function-name@npm:^7.29.7":
   version: 7.29.7
   resolution: "@babel/plugin-transform-function-name@npm:7.29.7"
   dependencies:
@@ -1429,18 +1428,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-literals@npm:^7.25.2":
-  version: 7.27.1
-  resolution: "@babel/plugin-transform-literals@npm:7.27.1"
-  dependencies:
-    "@babel/helper-plugin-utils": "npm:^7.27.1"
-  peerDependencies:
-    "@babel/core": ^7.0.0-0
-  checksum: 10c0/c40dc3eb2f45a92ee476412314a40e471af51a0f51a24e91b85cef5fc59f4fe06758088f541643f07f949d2c67ee7bdce10e11c5ec56791ae09b15c3b451eeca
-  languageName: node
-  linkType: hard
-
-"@babel/plugin-transform-literals@npm:^7.29.7":
+"@babel/plugin-transform-literals@npm:^7.25.2, @babel/plugin-transform-literals@npm:^7.29.7":
   version: 7.29.7
   resolution: "@babel/plugin-transform-literals@npm:7.29.7"
   dependencies:
@@ -1451,18 +1439,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-logical-assignment-operators@npm:^7.24.7":
-  version: 7.27.1
-  resolution: "@babel/plugin-transform-logical-assignment-operators@npm:7.27.1"
-  dependencies:
-    "@babel/helper-plugin-utils": "npm:^7.27.1"
-  peerDependencies:
-    "@babel/core": ^7.0.0-0
-  checksum: 10c0/5b0abc7c0d09d562bf555c646dce63a30288e5db46fd2ce809a61d064415da6efc3b2b3c59b8e4fe98accd072c89a2f7c3765b400e4bf488651735d314d9feeb
-  languageName: node
-  linkType: hard
-
-"@babel/plugin-transform-logical-assignment-operators@npm:^7.29.7":
+"@babel/plugin-transform-logical-assignment-operators@npm:^7.24.7, @babel/plugin-transform-logical-assignment-operators@npm:^7.29.7":
   version: 7.29.7
   resolution: "@babel/plugin-transform-logical-assignment-operators@npm:7.29.7"
   dependencies:
@@ -1603,18 +1580,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-numeric-separator@npm:^7.24.7":
-  version: 7.27.1
-  resolution: "@babel/plugin-transform-numeric-separator@npm:7.27.1"
-  dependencies:
-    "@babel/helper-plugin-utils": "npm:^7.27.1"
-  peerDependencies:
-    "@babel/core": ^7.0.0-0
-  checksum: 10c0/b72cbebbfe46fcf319504edc1cf59f3f41c992dd6840db766367f6a1d232cd2c52143c5eaf57e0316710bee251cae94be97c6d646b5022fcd9274ccb131b470c
-  languageName: node
-  linkType: hard
-
-"@babel/plugin-transform-numeric-separator@npm:^7.29.7":
+"@babel/plugin-transform-numeric-separator@npm:^7.24.7, @babel/plugin-transform-numeric-separator@npm:^7.29.7":
   version: 7.29.7
   resolution: "@babel/plugin-transform-numeric-separator@npm:7.29.7"
   dependencies:
@@ -1977,7 +1943,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-shorthand-properties@npm:^7.0.0-0, @babel/plugin-transform-shorthand-properties@npm:^7.24.7":
+"@babel/plugin-transform-shorthand-properties@npm:^7.0.0-0":
   version: 7.27.1
   resolution: "@babel/plugin-transform-shorthand-properties@npm:7.27.1"
   dependencies:
@@ -1988,7 +1954,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-shorthand-properties@npm:^7.29.7":
+"@babel/plugin-transform-shorthand-properties@npm:^7.24.7, @babel/plugin-transform-shorthand-properties@npm:^7.29.7":
   version: 7.29.7
   resolution: "@babel/plugin-transform-shorthand-properties@npm:7.29.7"
   dependencies:
@@ -2000,14 +1966,14 @@ __metadata:
   linkType: hard
 
 "@babel/plugin-transform-spread@npm:^7.24.7":
-  version: 7.27.1
-  resolution: "@babel/plugin-transform-spread@npm:7.27.1"
+  version: 7.29.8
+  resolution: "@babel/plugin-transform-spread@npm:7.29.8"
   dependencies:
-    "@babel/helper-plugin-utils": "npm:^7.27.1"
-    "@babel/helper-skip-transparent-expression-wrappers": "npm:^7.27.1"
+    "@babel/helper-plugin-utils": "npm:^7.29.7"
+    "@babel/helper-skip-transparent-expression-wrappers": "npm:^7.29.7"
   peerDependencies:
     "@babel/core": ^7.0.0-0
-  checksum: 10c0/b34fc58b33bd35b47d67416655c2cbc8578fbb3948b4592bc15eb6d8b4046986e25c06e3b9929460fa4ab08e9653582415e7ef8b87d265e1239251bdf5a4c162
+  checksum: 10c0/3af864918afb3389989b5ba5b196a376bb58d1c59657a978d12213766cf052bcf12e66165da6676e5aa08fa64f0c3ec78a124c38ce6b41b88810bb88ba9d0a89
   languageName: node
   linkType: hard
 
@@ -2023,18 +1989,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-sticky-regex@npm:^7.24.7":
-  version: 7.27.1
-  resolution: "@babel/plugin-transform-sticky-regex@npm:7.27.1"
-  dependencies:
-    "@babel/helper-plugin-utils": "npm:^7.27.1"
-  peerDependencies:
-    "@babel/core": ^7.0.0-0
-  checksum: 10c0/5698df2d924f0b1b7bdb7ef370e83f99ed3f0964eb3b9c27d774d021bee7f6d45f9a73e2be369d90b4aff1603ce29827f8743f091789960e7669daf9c3cda850
-  languageName: node
-  linkType: hard
-
-"@babel/plugin-transform-sticky-regex@npm:^7.29.7":
+"@babel/plugin-transform-sticky-regex@npm:^7.24.7, @babel/plugin-transform-sticky-regex@npm:^7.29.7":
   version: 7.29.7
   resolution: "@babel/plugin-transform-sticky-regex@npm:7.29.7"
   dependencies:
@@ -2341,7 +2296,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/template@npm:^7.25.0, @babel/template@npm:^7.27.1, @babel/template@npm:^7.27.2, @babel/template@npm:^7.3.3":
+"@babel/template@npm:^7.25.0, @babel/template@npm:^7.27.2, @babel/template@npm:^7.3.3":
   version: 7.27.2
   resolution: "@babel/template@npm:7.27.2"
   dependencies:
@@ -2352,7 +2307,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/template@npm:^7.29.7":
+"@babel/template@npm:^7.28.6, @babel/template@npm:^7.29.7":
   version: 7.29.7
   resolution: "@babel/template@npm:7.29.7"
   dependencies:
@@ -2378,6 +2333,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/traverse@npm:^7.29.0":
+  version: 7.29.8
+  resolution: "@babel/traverse@npm:7.29.8"
+  dependencies:
+    "@babel/code-frame": "npm:^7.29.7"
+    "@babel/generator": "npm:^7.29.8"
+    "@babel/helper-globals": "npm:^7.29.7"
+    "@babel/parser": "npm:^7.29.8"
+    "@babel/template": "npm:^7.29.7"
+    "@babel/types": "npm:^7.29.8"
+    debug: "npm:^4.3.1"
+  checksum: 10c0/87a28989c434add26d787776ac6d30f749b89cb030f2a605c89f671a516a6fa165ac0476f07e2b69feed70128b2734cae1cbbf41dfe95ccf22081bd8f8b91923
+  languageName: node
+  linkType: hard
+
 "@babel/traverse@npm:^7.29.7":
   version: 7.29.7
   resolution: "@babel/traverse@npm:7.29.7"
@@ -2400,6 +2370,16 @@ __metadata:
     "@babel/helper-string-parser": "npm:^7.27.1"
     "@babel/helper-validator-identifier": "npm:^7.27.1"
   checksum: 10c0/ac6f909d6191319e08c80efbfac7bd9a25f80cc83b43cd6d82e7233f7a6b9d6e7b90236f3af7400a3f83b576895bcab9188a22b584eb0f224e80e6d4e95f4517
+  languageName: node
+  linkType: hard
+
+"@babel/types@npm:^7.29.0, @babel/types@npm:^7.29.8":
+  version: 7.29.8
+  resolution: "@babel/types@npm:7.29.8"
+  dependencies:
+    "@babel/helper-string-parser": "npm:^7.29.7"
+    "@babel/helper-validator-identifier": "npm:^7.29.7"
+  checksum: 10c0/be7c279f0abf2a086c633e21b49c7ca80275d05283cc5a268b67a708c9914bd0c944f1422b3eb3cb37682a2af5d560abf520ccf9b01b53ecbfe6b71fbc3fdde6
   languageName: node
   linkType: hard
 
@@ -4363,10 +4343,32 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@react-native/jest-preset@npm:^0.85.0":
+  version: 0.85.3
+  resolution: "@react-native/jest-preset@npm:0.85.3"
+  dependencies:
+    "@jest/create-cache-key-function": "npm:^29.7.0"
+    "@react-native/js-polyfills": "npm:0.85.3"
+    babel-jest: "npm:^29.7.0"
+    jest-environment-node: "npm:^29.7.0"
+    regenerator-runtime: "npm:^0.13.2"
+  peerDependencies:
+    react: ^19.2.3
+  checksum: 10c0/7c18a87432978d8e05bb66401d6591a99e1aaf575a206afd0a120611359c8addf7259ecf9f1ccb162fd2bd23412eaf8d7791168718bbe180e397a219806a302f
+  languageName: node
+  linkType: hard
+
 "@react-native/js-polyfills@npm:0.81.4":
   version: 0.81.4
   resolution: "@react-native/js-polyfills@npm:0.81.4"
   checksum: 10c0/3a9fe20f257562c9971d1115973441fe41f8d4a8f3530aa5d269ce7dd0d25a4854f009b772e6f8d17b6ad5e88b739b06d3d6018228b4305c2922d3f087ef9697
+  languageName: node
+  linkType: hard
+
+"@react-native/js-polyfills@npm:0.85.3":
+  version: 0.85.3
+  resolution: "@react-native/js-polyfills@npm:0.85.3"
+  checksum: 10c0/67c4ed8234cbeb6d5250b06901f352ddd5348f9aad88aac8a06dc884f42e0da22ff2e1ca8e06c7d03e1e659486bdb9d7682f34858ebf9398d7ae199ce02b3749
   languageName: node
   linkType: hard
 
@@ -5108,6 +5110,16 @@ __metadata:
     mime-types: "npm:~2.1.34"
     negotiator: "npm:0.6.3"
   checksum: 10c0/3a35c5f5586cfb9a21163ca47a5f77ac34fa8ceb5d17d2fa2c0d81f41cbd7f8c6fa52c77e2c039acc0f4d09e71abdc51144246900f6bef5e3c4b333f77d89362
+  languageName: node
+  linkType: hard
+
+"accepts@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "accepts@npm:2.0.0"
+  dependencies:
+    mime-types: "npm:^3.0.0"
+    negotiator: "npm:^1.0.0"
+  checksum: 10c0/98374742097e140891546076215f90c32644feacf652db48412329de4c2a529178a81aa500fbb13dd3e6cbf6e68d829037b123ac037fc9a08bcec4b87b358eef
   languageName: node
   linkType: hard
 
@@ -8392,17 +8404,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"hermes-estree@npm:0.32.0":
-  version: 0.32.0
-  resolution: "hermes-estree@npm:0.32.0"
-  checksum: 10c0/3b67d1fe44336240ef7f9c40ecbf363279ba263d51efe120570c3862cc109e652fc09aebddfe6b73d0f0246610bee130e4064c359f1f4cbf002bdb1d99717ef2
-  languageName: node
-  linkType: hard
-
 "hermes-estree@npm:0.34.0":
   version: 0.34.0
   resolution: "hermes-estree@npm:0.34.0"
   checksum: 10c0/bd4ad520838c69aa79887230a2030fe1e07d0826389112e2c23a8b18494f9f2fa6b1639f413ad978f3468daea66903869188481f9500aaa1fb79ed6266afb744
+  languageName: node
+  linkType: hard
+
+"hermes-estree@npm:0.35.0":
+  version: 0.35.0
+  resolution: "hermes-estree@npm:0.35.0"
+  checksum: 10c0/a88c9dc63b8b3679b1aeb43e72e977597096c1bd7d59978c952f1d6df6d1a517c4a817c70b1b701854996b485adfa66c2fc7f80871029a7f0c04306f6717b59a
   languageName: node
   linkType: hard
 
@@ -8415,21 +8427,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"hermes-parser@npm:0.32.0":
-  version: 0.32.0
-  resolution: "hermes-parser@npm:0.32.0"
-  dependencies:
-    hermes-estree: "npm:0.32.0"
-  checksum: 10c0/5902d2c5d347c0629fba07a47eaad5569590ac69bc8bfb2e454e08d2dfbe1ebd989d88518dca2cba64061689b5eac5960ae6bd15a4a66600bbf377498a3234b7
-  languageName: node
-  linkType: hard
-
 "hermes-parser@npm:0.34.0":
   version: 0.34.0
   resolution: "hermes-parser@npm:0.34.0"
   dependencies:
     hermes-estree: "npm:0.34.0"
   checksum: 10c0/e20657a21ebc3187f53780f5f2c5dd7434f4371979d05b016ff06306b6db63f9d2575ee60c63e9e7d831dd0f592542193a50a6e8397678d4a312fc5373bbe382
+  languageName: node
+  linkType: hard
+
+"hermes-parser@npm:0.35.0":
+  version: 0.35.0
+  resolution: "hermes-parser@npm:0.35.0"
+  dependencies:
+    hermes-estree: "npm:0.35.0"
+  checksum: 10c0/49d98093a2094758db5b536627c6cf5146b140f66e63143acf471c62f1d3fd8bd6ae10a33f2372f72e3653deda5d4615c6dae89d01248849440916209901fc4a
   languageName: node
   linkType: hard
 
@@ -10444,15 +10456,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"metro-babel-transformer@npm:0.83.2":
-  version: 0.83.2
-  resolution: "metro-babel-transformer@npm:0.83.2"
+"metro-babel-transformer@npm:0.83.7":
+  version: 0.83.7
+  resolution: "metro-babel-transformer@npm:0.83.7"
   dependencies:
     "@babel/core": "npm:^7.25.2"
     flow-enums-runtime: "npm:^0.0.6"
-    hermes-parser: "npm:0.32.0"
+    hermes-parser: "npm:0.35.0"
+    metro-cache-key: "npm:0.83.7"
     nullthrows: "npm:^1.1.1"
-  checksum: 10c0/8f3005c6534eb62816fa85a321c891b1dd64f4ac92d7dc7eedbfe06b4fffd2e3f629d0641ffd87373c6d28152c701faf36c7f7a4b0ed6624aa2b3c922d6026ae
+  checksum: 10c0/c50c2fe9fa3d3fbe382d8a482ebcc77d7dba0ef4673cee4904a55b9ea28dea4b86d3b80e9b9ac0cd2b094b9ecd0368c953bba0f1df1cfd36c3a27c666352fd86
   languageName: node
   linkType: hard
 
@@ -10465,12 +10478,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"metro-cache-key@npm:0.83.2":
-  version: 0.83.2
-  resolution: "metro-cache-key@npm:0.83.2"
+"metro-cache-key@npm:0.83.7":
+  version: 0.83.7
+  resolution: "metro-cache-key@npm:0.83.7"
   dependencies:
     flow-enums-runtime: "npm:^0.0.6"
-  checksum: 10c0/791517bcd997d2f8ecaba3aff99714408f1c80d938846c7b8d114e346ce93c963eb103317e4781b3c16ad187ed95b8e23397346bb6cb4b86ec8ff95dbda4681e
+  checksum: 10c0/a2f20b86b173cd2be710552a49e6389a2c9ef994ac35873616bd4e5c34588beb8c93279bcf525295ca73b6d206ab0d9942f35cbd4a76e642d359bdab48924d7a
   languageName: node
   linkType: hard
 
@@ -10486,15 +10499,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"metro-cache@npm:0.83.2":
-  version: 0.83.2
-  resolution: "metro-cache@npm:0.83.2"
+"metro-cache@npm:0.83.7":
+  version: 0.83.7
+  resolution: "metro-cache@npm:0.83.7"
   dependencies:
     exponential-backoff: "npm:^3.1.1"
     flow-enums-runtime: "npm:^0.0.6"
     https-proxy-agent: "npm:^7.0.5"
-    metro-core: "npm:0.83.2"
-  checksum: 10c0/2c8d4004153431abb73265496ba2ede5e5fd09c2ca3769186ebe5b87645c97d74b871cc1bf83ab6bccdae596039341e330df3ebfab6e8469e1207e6a5d0e9ebc
+    metro-core: "npm:0.83.7"
+  checksum: 10c0/81ae4b2d0d389d25b816bb2d59eb8baed5e1f03a727aa9bcecadb5547e949525f90af888c956fbd5ff4a732cf4dc48b6d903bab648d23dc1830135d820040825
   languageName: node
   linkType: hard
 
@@ -10514,19 +10527,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"metro-config@npm:0.83.2, metro-config@npm:^0.83.1":
-  version: 0.83.2
-  resolution: "metro-config@npm:0.83.2"
+"metro-config@npm:0.83.7, metro-config@npm:^0.83.1":
+  version: 0.83.7
+  resolution: "metro-config@npm:0.83.7"
   dependencies:
     connect: "npm:^3.6.5"
     flow-enums-runtime: "npm:^0.0.6"
     jest-validate: "npm:^29.7.0"
-    metro: "npm:0.83.2"
-    metro-cache: "npm:0.83.2"
-    metro-core: "npm:0.83.2"
-    metro-runtime: "npm:0.83.2"
+    metro: "npm:0.83.7"
+    metro-cache: "npm:0.83.7"
+    metro-core: "npm:0.83.7"
+    metro-runtime: "npm:0.83.7"
     yaml: "npm:^2.6.1"
-  checksum: 10c0/224dff59b53f23ca4a0f39e8a82c297b93c779e9f92c1e097c1ac9fd66d86978b696476aef14a2eb3d2b4704adfb53e3d7ab76abf32924a06f3f6d0c586ac16f
+  checksum: 10c0/04f9ae008a4972d8399ed90dc03286afefabc2fc362fef8b8f362ec9c09f2edfe3f0f9e0e5aebf42de8b253f202629cc8e86ef0b07e205adf257cd609ac386fb
   languageName: node
   linkType: hard
 
@@ -10541,14 +10554,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"metro-core@npm:0.83.2, metro-core@npm:^0.83.1":
-  version: 0.83.2
-  resolution: "metro-core@npm:0.83.2"
+"metro-core@npm:0.83.7, metro-core@npm:^0.83.1":
+  version: 0.83.7
+  resolution: "metro-core@npm:0.83.7"
   dependencies:
     flow-enums-runtime: "npm:^0.0.6"
     lodash.throttle: "npm:^4.1.1"
-    metro-resolver: "npm:0.83.2"
-  checksum: 10c0/3582bfb114fbda2c9bb5cdde1a185ba0c707a27f325a6e63c6a981c9a05e02965dcfcc8c98cc37f30ef8e103f34e4f7b544e67f61f1dcdfc1bf81d98b27507f8
+    metro-resolver: "npm:0.83.7"
+  checksum: 10c0/cd267b2516ccce0cc152d12ff1f08073abec0a9b210779357a43f1a279acb3c3be0ff625de030da9a110aea45b70e36f14e13b846cb4fee8419fae67db2a53b4
   languageName: node
   linkType: hard
 
@@ -10569,9 +10582,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"metro-file-map@npm:0.83.2":
-  version: 0.83.2
-  resolution: "metro-file-map@npm:0.83.2"
+"metro-file-map@npm:0.83.7":
+  version: 0.83.7
+  resolution: "metro-file-map@npm:0.83.7"
   dependencies:
     debug: "npm:^4.4.0"
     fb-watchman: "npm:^2.0.0"
@@ -10582,7 +10595,7 @@ __metadata:
     micromatch: "npm:^4.0.4"
     nullthrows: "npm:^1.1.1"
     walker: "npm:^1.0.7"
-  checksum: 10c0/0577c06c7c7f1325a9c9121a304de13c632f783e4a4fe149b1b532ae88d375f199803ea75ff56e979867d4969326a297336ac815ee494ba057eec600a129bb58
+  checksum: 10c0/467729e9f607552504d9e1b9a8d81e5ea5a27f979f19a40360215773b38e1a3b563789047f06a5502cf5983aae922b3c52f5a7e0be8edc0b0bb747556e7d5af8
   languageName: node
   linkType: hard
 
@@ -10596,13 +10609,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"metro-minify-terser@npm:0.83.2":
-  version: 0.83.2
-  resolution: "metro-minify-terser@npm:0.83.2"
+"metro-minify-terser@npm:0.83.7":
+  version: 0.83.7
+  resolution: "metro-minify-terser@npm:0.83.7"
   dependencies:
     flow-enums-runtime: "npm:^0.0.6"
     terser: "npm:^5.15.0"
-  checksum: 10c0/0bf1cb557d30c82b701c2cb8a89f92c93ebb54891bd88dc3a504783e2038825bbde77095b0c9ff74069e09b170742b8fe37f5f9233e421a41c997fe5b3303d66
+  checksum: 10c0/bf59f9b5a51c3cfff313f64daab78673fa17d3c9d0ec34823d295cd454daa146daa23706f4cae36104bc41f10ad7b5fa2802246891a6f5eb4d0736ef891c9c7a
   languageName: node
   linkType: hard
 
@@ -10615,12 +10628,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"metro-resolver@npm:0.83.2":
-  version: 0.83.2
-  resolution: "metro-resolver@npm:0.83.2"
+"metro-resolver@npm:0.83.7":
+  version: 0.83.7
+  resolution: "metro-resolver@npm:0.83.7"
   dependencies:
     flow-enums-runtime: "npm:^0.0.6"
-  checksum: 10c0/1094ffa21f8f5273cd0f43d663806a62ed45841c7b4e51f1a823437e0659a98e13829ab18e419e2cfb3cbd097e0263c75e7937a92c5da69718458adec6c4ca51
+  checksum: 10c0/be5ba43302362f3918ef4a1f91f96d63c04469cc9fed076a2846785f60f7f53193278a36d249b92a4678fcf95f7a6e31da87a13df82ddc384f010c80fd3b074d
   languageName: node
   linkType: hard
 
@@ -10634,13 +10647,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"metro-runtime@npm:0.83.2, metro-runtime@npm:^0.83.1":
-  version: 0.83.2
-  resolution: "metro-runtime@npm:0.83.2"
+"metro-runtime@npm:0.83.7, metro-runtime@npm:^0.83.1":
+  version: 0.83.7
+  resolution: "metro-runtime@npm:0.83.7"
   dependencies:
     "@babel/runtime": "npm:^7.25.0"
     flow-enums-runtime: "npm:^0.0.6"
-  checksum: 10c0/1eb13af44f47bc490ed663d6ad3024c95cfbc4117c281e60adbb5cd56e3813e3e9e4344b2e2b2e8db517411f3f7a18dadd71c96a7f79b7d019c6326221648564
+  checksum: 10c0/b9feb9cffdf4df086cea91d803529d706c1a212d0c6b9d138ef4985905cb9bd22f9861a77061364a397917b772d2ef722e465a5b198d6405f574481dfa35a9a7
   languageName: node
   linkType: hard
 
@@ -10672,21 +10685,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"metro-source-map@npm:0.83.2, metro-source-map@npm:^0.83.1":
-  version: 0.83.2
-  resolution: "metro-source-map@npm:0.83.2"
+"metro-source-map@npm:0.83.7, metro-source-map@npm:^0.83.1":
+  version: 0.83.7
+  resolution: "metro-source-map@npm:0.83.7"
   dependencies:
-    "@babel/traverse": "npm:^7.25.3"
-    "@babel/traverse--for-generate-function-map": "npm:@babel/traverse@^7.25.3"
-    "@babel/types": "npm:^7.25.2"
+    "@babel/traverse": "npm:^7.29.0"
+    "@babel/types": "npm:^7.29.0"
     flow-enums-runtime: "npm:^0.0.6"
     invariant: "npm:^2.2.4"
-    metro-symbolicate: "npm:0.83.2"
+    metro-symbolicate: "npm:0.83.7"
     nullthrows: "npm:^1.1.1"
-    ob1: "npm:0.83.2"
+    ob1: "npm:0.83.7"
     source-map: "npm:^0.5.6"
     vlq: "npm:^1.0.0"
-  checksum: 10c0/1590e9e50389f607dff1283fa70a770dfce1be44299062e8a538f0dd75b63307ea8661495ca64ad9994898e3dd0d1dc995023ddd9b67dd304de3b259a105056c
+  checksum: 10c0/6c424f6258a2128bb4ae6e7591fb7ed1f79b042978397c24a1e35d8bdfcd8960655b3cdd0c4d8ff90f3055ce5b00eca5cb61b327720e7029b3f334fd8ae1776d
   languageName: node
   linkType: hard
 
@@ -10706,19 +10718,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"metro-symbolicate@npm:0.83.2":
-  version: 0.83.2
-  resolution: "metro-symbolicate@npm:0.83.2"
+"metro-symbolicate@npm:0.83.7":
+  version: 0.83.7
+  resolution: "metro-symbolicate@npm:0.83.7"
   dependencies:
     flow-enums-runtime: "npm:^0.0.6"
     invariant: "npm:^2.2.4"
-    metro-source-map: "npm:0.83.2"
+    metro-source-map: "npm:0.83.7"
     nullthrows: "npm:^1.1.1"
     source-map: "npm:^0.5.6"
     vlq: "npm:^1.0.0"
   bin:
     metro-symbolicate: src/index.js
-  checksum: 10c0/0c021d63520a9f8daaa70165d42c3050f46de31a02ed372aef19ca3027c5beddb14cf9623942142ff493680c094057d7314f2d712419231f3ff3dcf77f18f790
+  checksum: 10c0/4968a89d9bdd040e0cb6328852f14a8555e912875a1661e639566879e548fbfb849134b8f55076f875c062d202c713be1c9f47b4e68c627a4f8b367d7e208213
   languageName: node
   linkType: hard
 
@@ -10736,17 +10748,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"metro-transform-plugins@npm:0.83.2":
-  version: 0.83.2
-  resolution: "metro-transform-plugins@npm:0.83.2"
+"metro-transform-plugins@npm:0.83.7":
+  version: 0.83.7
+  resolution: "metro-transform-plugins@npm:0.83.7"
   dependencies:
     "@babel/core": "npm:^7.25.2"
-    "@babel/generator": "npm:^7.25.0"
-    "@babel/template": "npm:^7.25.0"
-    "@babel/traverse": "npm:^7.25.3"
+    "@babel/generator": "npm:^7.29.1"
+    "@babel/template": "npm:^7.28.6"
+    "@babel/traverse": "npm:^7.29.0"
     flow-enums-runtime: "npm:^0.0.6"
     nullthrows: "npm:^1.1.1"
-  checksum: 10c0/55925ace9b878721b478f0c0e95abdbd7d834c4738611a6b5c4a3e457a0f01c81b17356c3158fd70960c7f01b43ff641de2b2ad28888afaac21d73c541820ee1
+  checksum: 10c0/2fce17ba1013e96278bd6800141ff050af0331a60c4c0dbc24f83c6b524806b6ff4089b36e3268c2315375211d16e875d644b7cbf2b23d43dc050047ec019556
   languageName: node
   linkType: hard
 
@@ -10771,24 +10783,24 @@ __metadata:
   languageName: node
   linkType: hard
 
-"metro-transform-worker@npm:0.83.2":
-  version: 0.83.2
-  resolution: "metro-transform-worker@npm:0.83.2"
+"metro-transform-worker@npm:0.83.7":
+  version: 0.83.7
+  resolution: "metro-transform-worker@npm:0.83.7"
   dependencies:
     "@babel/core": "npm:^7.25.2"
-    "@babel/generator": "npm:^7.25.0"
-    "@babel/parser": "npm:^7.25.3"
-    "@babel/types": "npm:^7.25.2"
+    "@babel/generator": "npm:^7.29.1"
+    "@babel/parser": "npm:^7.29.0"
+    "@babel/types": "npm:^7.29.0"
     flow-enums-runtime: "npm:^0.0.6"
-    metro: "npm:0.83.2"
-    metro-babel-transformer: "npm:0.83.2"
-    metro-cache: "npm:0.83.2"
-    metro-cache-key: "npm:0.83.2"
-    metro-minify-terser: "npm:0.83.2"
-    metro-source-map: "npm:0.83.2"
-    metro-transform-plugins: "npm:0.83.2"
+    metro: "npm:0.83.7"
+    metro-babel-transformer: "npm:0.83.7"
+    metro-cache: "npm:0.83.7"
+    metro-cache-key: "npm:0.83.7"
+    metro-minify-terser: "npm:0.83.7"
+    metro-source-map: "npm:0.83.7"
+    metro-transform-plugins: "npm:0.83.7"
     nullthrows: "npm:^1.1.1"
-  checksum: 10c0/ea8a0e6bdf24dc5719edb0f2aae0e5bf70f6801cebed8a952fd2d3a1eec95640ac1176d0132faa878897b524ff9828a07810ff22e8a82f007f235d470b027e93
+  checksum: 10c0/a84e3bae6679826059d66bc9438f00292d93569bdefb4193bcbe4c9a72f5423d88d8d3da94389f95674674118af1ee233ac8a2b5b8279ff568c8becf4c609f1c
   languageName: node
   linkType: hard
 
@@ -10842,44 +10854,43 @@ __metadata:
   languageName: node
   linkType: hard
 
-"metro@npm:0.83.2, metro@npm:^0.83.1":
-  version: 0.83.2
-  resolution: "metro@npm:0.83.2"
+"metro@npm:0.83.7, metro@npm:^0.83.1":
+  version: 0.83.7
+  resolution: "metro@npm:0.83.7"
   dependencies:
-    "@babel/code-frame": "npm:^7.24.7"
+    "@babel/code-frame": "npm:^7.29.0"
     "@babel/core": "npm:^7.25.2"
-    "@babel/generator": "npm:^7.25.0"
-    "@babel/parser": "npm:^7.25.3"
-    "@babel/template": "npm:^7.25.0"
-    "@babel/traverse": "npm:^7.25.3"
-    "@babel/types": "npm:^7.25.2"
-    accepts: "npm:^1.3.7"
-    chalk: "npm:^4.0.0"
+    "@babel/generator": "npm:^7.29.1"
+    "@babel/parser": "npm:^7.29.0"
+    "@babel/template": "npm:^7.28.6"
+    "@babel/traverse": "npm:^7.29.0"
+    "@babel/types": "npm:^7.29.0"
+    accepts: "npm:^2.0.0"
     ci-info: "npm:^2.0.0"
     connect: "npm:^3.6.5"
     debug: "npm:^4.4.0"
     error-stack-parser: "npm:^2.0.6"
     flow-enums-runtime: "npm:^0.0.6"
     graceful-fs: "npm:^4.2.4"
-    hermes-parser: "npm:0.32.0"
+    hermes-parser: "npm:0.35.0"
     image-size: "npm:^1.0.2"
     invariant: "npm:^2.2.4"
     jest-worker: "npm:^29.7.0"
     jsc-safe-url: "npm:^0.2.2"
     lodash.throttle: "npm:^4.1.1"
-    metro-babel-transformer: "npm:0.83.2"
-    metro-cache: "npm:0.83.2"
-    metro-cache-key: "npm:0.83.2"
-    metro-config: "npm:0.83.2"
-    metro-core: "npm:0.83.2"
-    metro-file-map: "npm:0.83.2"
-    metro-resolver: "npm:0.83.2"
-    metro-runtime: "npm:0.83.2"
-    metro-source-map: "npm:0.83.2"
-    metro-symbolicate: "npm:0.83.2"
-    metro-transform-plugins: "npm:0.83.2"
-    metro-transform-worker: "npm:0.83.2"
-    mime-types: "npm:^2.1.27"
+    metro-babel-transformer: "npm:0.83.7"
+    metro-cache: "npm:0.83.7"
+    metro-cache-key: "npm:0.83.7"
+    metro-config: "npm:0.83.7"
+    metro-core: "npm:0.83.7"
+    metro-file-map: "npm:0.83.7"
+    metro-resolver: "npm:0.83.7"
+    metro-runtime: "npm:0.83.7"
+    metro-source-map: "npm:0.83.7"
+    metro-symbolicate: "npm:0.83.7"
+    metro-transform-plugins: "npm:0.83.7"
+    metro-transform-worker: "npm:0.83.7"
+    mime-types: "npm:^3.0.1"
     nullthrows: "npm:^1.1.1"
     serialize-error: "npm:^2.1.0"
     source-map: "npm:^0.5.6"
@@ -10888,7 +10899,7 @@ __metadata:
     yargs: "npm:^17.6.2"
   bin:
     metro: src/cli.js
-  checksum: 10c0/4c3cc7c2a455471d05757b567a0f2ca604a33f55ffbf2d838dbba8519396f2514b00d6a9214af288343be0277655e3397f2e7816506ec41aed16a9fa54585018
+  checksum: 10c0/f759631778ce2e8cd7e1338ec886ffa0e3d4cd8456d5a506c57e5212206519435a345bcac6334dac22b3adf188b34854688007ddb1669c65afbadf0a0eef431a
   languageName: node
   linkType: hard
 
@@ -10916,7 +10927,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"mime-types@npm:3.0.2":
+"mime-types@npm:3.0.2, mime-types@npm:^3.0.0, mime-types@npm:^3.0.1":
   version: 3.0.2
   resolution: "mime-types@npm:3.0.2"
   dependencies:
@@ -11362,12 +11373,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ob1@npm:0.83.2":
-  version: 0.83.2
-  resolution: "ob1@npm:0.83.2"
+"ob1@npm:0.83.7":
+  version: 0.83.7
+  resolution: "ob1@npm:0.83.7"
   dependencies:
     flow-enums-runtime: "npm:^0.0.6"
-  checksum: 10c0/fadcdb9e801458ebc66a09554d3535978e031e1c29e1d450f64f4d8da53ba1505b029726349a3211c5d388af49d1e8bb4f50304526ca237cb2b861177eeea327
+  checksum: 10c0/b009d7a79b7ccf8db520acdc713a544a1ec379ae804438328080715c66944aa871551b8d7b1cf7cfb89cbe53bbab29f3345097c455259d7b7fe76b0891860187
   languageName: node
   linkType: hard
 
@@ -12188,9 +12199,9 @@ __metadata:
   linkType: hard
 
 "react-is@npm:^19.1.0":
-  version: 19.1.1
-  resolution: "react-is@npm:19.1.1"
-  checksum: 10c0/3dba763fcd69835ae263dcd6727d7ffcc44c1d616f04b7329e67aefdc66a567af4f8dcecdd29454c7a707c968aa1eb85083a83fb616f01675ef25e71cf082f97
+  version: 19.2.8
+  resolution: "react-is@npm:19.2.8"
+  checksum: 10c0/ed5322c84efe035c8fc814b1614ff5ca7fb8c2872a7c045197daf99f9b1bd68f32a2c79ffcbcfcff2fc5d93924ff9f9447400898f5b1534e6302bb0736a257f0
   languageName: node
   linkType: hard
 
@@ -12266,6 +12277,7 @@ __metadata:
     "@eslint/js": "npm:^10.0.1"
     "@expo/metro-config": "npm:~54.0.5"
     "@ianvs/prettier-plugin-sort-imports": "npm:^4.4.2"
+    "@react-native/jest-preset": "npm:^0.85.0"
     "@release-it/conventional-changelog": "npm:10.0.1"
     "@tailwindcss/postcss": "npm:^4.1.12"
     "@testing-library/react-native": "npm:^13.3.3"


### PR DESCRIPTION
`peerDependencies` says `react-native: ">=0.81"`. **0.81 is the only minor in that range the package compiles on.** Measured with `yarn typecheck` at `f70c402`, one install per version:

| `react-native` | errors |
| --- | --- |
| 0.81.4 | **0** |
| 0.82.0 | **6** |
| 0.83.0 | **7** |
| 0.84.0 | **7** |
| 0.85.3 | **7** |
| 0.86.0 | **7** |

Two unrelated causes, with different start points, plus a jest bootstrap failure that makes the suite unrunnable on 0.86. This PR makes all six compile and keeps 0.81 exactly where it is.

The seven on 0.86:

```
src/components/FlatList.tsx(12,16): error TS2590: Expression produces a union type that is too complex to represent.
src/jest/index.ts(24,29): error TS2345: Argument of type 'null' is not assignable to parameter of type 'ColorSchemeName'.
src/jest/index.ts(25,19): error TS2345: Argument of type 'null' is not assignable to parameter of type 'Value'.
src/native/api.tsx(76,31): error TS2345: Argument of type 'string' is not assignable to parameter of type 'Value'.
src/native/reactivity.ts(220,3): error TS2345: Argument of type 'ColorSchemeName | null | undefined' is not assignable to parameter of type 'ColorSchemeName | Read<ColorSchemeName, ColorSchemeName>'.
src/native/reactivity.ts(222,57): error TS2345: Argument of type 'string' is not assignable to parameter of type 'Value'.
src/web/api.tsx(72,3): error TS2322: Type '() => ColorSchemeName | null | undefined' is not assignable to type '() => ColorSchemeName'.
```

## 1. `ColorSchemeName` inverts at 0.82 (6 errors, 0.82 and later)

`react-native`'s own type changes meaning inside the declared range:

| | `ColorSchemeName` | `Appearance.setColorScheme` accepts | `null` at runtime |
| --- | --- | --- | --- |
| 0.81 | `"light" \| "dark" \| null \| undefined` | `ColorSchemeName \| null \| undefined` | mapped to `"unspecified"` |
| 0.82+ | `"light" \| "dark" \| "unspecified"` | `ColorSchemeName` — `null` rejected | passed straight through |

`runtime.types.ts` re-exported that type as `ColorScheme`'s parameter and return, so the package's public API changed shape with the installed `react-native`, and the implementation could not satisfy both ends. The four errors reporting a bare generic `Value` are cascades of the failed `observable<ColorSchemeName>(...)` call at `reactivity.ts:220`.

The two `setColorScheme` parameter types overlap only on `"light" | "dark"`, so **no literal naming "follow the system" type-checks on both**. The runtime does not split the same way: `"unspecified"` is what the native module receives on every version, because 0.81 maps `null` to it on the way in.

`ColorSchemeName` is now the package's own union of every spelling, `"light" | "dark" | "unspecified" | null | undefined`. Both directions widen, so nothing a caller passes today stops working, and `"unspecified"` becomes writable on 0.81 too. The one incompatible call goes through `setAppearanceColorScheme`: `"light"` and `"dark"` keep the shared declaration, everything else is written as `"unspecified"` through a locally restated signature — one place, reason inline, covering only the value the versions disagree about.

## 2. `DotNotation` walks into component instances (TS2590, 0.83 and later)

Different cause, so worth reading separately.

`ScrollViewProps.scrollViewRef` is a `RefObject<ScrollView>`, and `ScrollView` carries `ScrollViewProps` again — the prop graph `DotNotation` enumerates is cyclic. Bounded at `MaxDepth 10`, that one prop contributes **4,654 paths on 0.81**. From 0.83 the host instance surface is wide enough that building the union crosses TypeScript's 100,000-member limit, so `StyledConfiguration<typeof FlatList>` fails and takes `src/components/FlatList.tsx` with it. `FlatList.d.ts` is unchanged across all of these versions; the growth is underneath it.

None of those paths can ever be a mapping target — they run through an object that does not exist until render. Treating a class component instance as a leaf removes the cycle at its source. Lowering `MaxDepth` would only move the threshold to whichever prop type grows next.

Path-set diff on 0.81, where the old and new definitions both resolve:

| | before | after | removed | added |
| --- | --- | --- | --- | --- |
| `ViewProps` | 733 | 733 | 0 | 0 |
| `ScrollViewProps` | 7,482 | 2,094 | 5,388 | 0 |
| `FlatListProps<unknown>` | 9,204 | 3,816 | 5,388 | 0 |
| `Pick<ScrollViewProps, "scrollViewRef">` | 4,656 | 2 | 4,654 | 0 |

Every removed path traverses a ref (`.current.`). Nothing is added.

## 3. The suite cannot bootstrap on 0.86

Independent of the types, and a prerequisite for testing any of this. `jest-expo@56` declares `@react-native/jest-preset` as a **non-optional** peer and resolves `setupFiles` and `testEnvironment` through it. Nothing provided it, so the suite ran on the copy `react-native` shipped in-tree. 0.86 deleted that copy; its `jest-preset.js` is now a shim that throws, and `.config/jest.config.cjs` dies before a single test loads:

```
The React Native Jest preset that jest-expo relies on has moved to a separate package.
    at Object.<anonymous> (node_modules/jest-expo/jest-preset.js:16:13)
    at Object.<anonymous> (.config/jest.config.cjs:4:18)
```

The package has no 0.81.x release — 0.85.0 is the first — so it cannot be pinned to this repo's `react-native`. `^0.85.0` matches jest-expo's own declared range and works at both ends. On 0.81.4 it is a no-op: the suite is bit-identical with and without it.

## Verification

**Typecheck, every minor in the range**, one install each, root and `example/` manifests moved together:

| | 0.81.4 | 0.82.0 | 0.83.0 | 0.84.0 | 0.85.3 | 0.86.0 |
| --- | --- | --- | --- | --- | --- | --- |
| `upstream/main` | 0 | 6 | 7 | 7 | 7 | 7 |
| this branch | **0** | **0** | **0** | **0** | **0** | **0** |

**Lint, build and the full suite at both ends of the range:**

| | `react-native@0.81.4` | `react-native@0.86.0` |
| --- | --- | --- |
| `yarn lint` | clean | clean |
| `yarn build` | ok | ok |
| `yarn test` | `3 failed, 21 skipped, 1055 passed, 1079 total` | `3 failed, 21 skipped, 1055 passed, 1079 total` |

Identical, with `numRuntimeErrorTestSuites: 0` on each — every suite loaded. The 3 failures are pre-existing on `main` before this branch: `babel-plugin-tester` path mismatches over an unrewritten relative `require("../View")`, reproducing on Windows only. Every figure above is the second of two consecutive runs, since a cold first run in a fresh tree can drop suites and silently subtract their whole count.

Running the suite on 0.86 also needs `@react-native/babel-preset` at 0.86 — `babel-preset-expo@54` pins 0.81.4, whose codegen plugin cannot parse 0.86's native component specs (`Unable to determine event arguments for "onChange"`, 21 suites down). That is an Expo SDK pairing issue rather than anything in this package, so it is not in the diff; I pinned it through `resolutions` locally for the measurement only.

## Tests

Both fixes are type-surface, so each carries a compile-plane assertion, and the color scheme one carries a runtime assertion as well.

`src/__tests__/native/color-scheme.test.tsx`

- Compile plane: three aliases assert `ColorSchemeName` covers `react-native`'s own union, `Appearance.getColorScheme()`'s return, and the change-listener payload. They are read off the **installed** `react-native` rather than restating either spelling, so `yarn typecheck` fails at whichever version the checkout is on the moment coverage lapses.
- Runtime plane: `NativeAppearance` is mocked so writes are observable — it is `TurboModuleRegistry.get('Appearance')`, null under jest on every version, which is why `setColorScheme` was previously unobservable in tests. Five cases assert what the native module actually receives; a sixth asserts `@media (prefers-color-scheme: dark)` engages on `"dark"` and releases on `"unspecified"`.

`src/__tests__/native/components.test.tsx`

- Compile plane: `scrollViewRef` and `scrollViewRef.current` are reachable targets, and a `@ts-expect-error` pins that `scrollViewRef.current.props.style` is not. That directive is what makes the guard work on 0.81 and 0.82 too, where TS2590 never fires — reverting the fix there fails with `TS2578: Unused '@ts-expect-error' directive`.
- No runtime plane: `dot-notation.types.ts` compiles to `export {}` (72 bytes), so it has no runtime surface. `FlatList`'s mapping behaviour is already covered by `className-with-style.test.tsx`, which passes at both ends.

Each fix was mutation-proved by reverting it and watching the guard go red:

| Reverted | 0.81.4 | 0.86.0 |
| --- | --- | --- |
| component-instance leaf | `TS2578` unused `@ts-expect-error` | `TS2578` + the original `FlatList.tsx(12,16) TS2590` |
| package-owned `ColorSchemeName` | `TS2345` on `colorScheme.set("unspecified")` | that plus the original `web/api.tsx TS2322` |
| `setAppearanceColorScheme` sends the raw value | **passes** — 0.81 maps `null` itself, so this version cannot see it | 2 tests red: native module receives `null` / `undefined` |
| `@react-native/jest-preset` devDependency | no effect — in-tree preset still resolves | jest config fails to load, whole suite unrunnable |

## Out of scope, noticed while here

`react-native-web@0.21`'s `Appearance` exports `getColorScheme` and `addChangeListener` but no `setColorScheme`, so `colorScheme.set()` on web throws `TypeError` at runtime today. Unrelated to this, and unchanged by this PR.
