### PR TITLE
fix(native): a custom property with no value produces no key

### DIFF
--- a/src/__tests__/native/variables.test.tsx
+++ b/src/__tests__/native/variables.test.tsx
@@ -2,9 +2,12 @@ import { memo, useEffect } from "react";
 import type { ViewProps } from "react-native";
 
 import { render, screen } from "@testing-library/react-native";
-import { styled, VariableContextProvider } from "react-native-css";
+import { styled } from "react-native-css";
 import { View } from "react-native-css/components/View";
 import { registerCSS, testID } from "react-native-css/jest";
+// `react-native-css` is the web surface to TypeScript, so the native
+// `VariableContextProvider` signature is reached through `/native`.
+import { VariableContextProvider } from "react-native-css/native";
 
 test("inline variable", () => {
   registerCSS(`.my-class { width: var(--my-var); --my-var: 10px; }`);
@@ -240,6 +243,83 @@ test("VariableContextProvider", () => {
 
   const component = screen.getByTestId(testID);
   expect(component.props.style).toStrictEqual({ color: "red" });
+});
+
+test("VariableContextProvider ignores an undefined value", () => {
+  // Two definitions, so the compiler cannot inline `--my-var` and the value is
+  // read at runtime. A single definition is folded into the declaration and
+  // never reaches the variable record this test is about.
+  registerCSS(`
+    .other { --my-var: blue; }
+    .other-2 { --my-var: purple; }
+    .test { color: var(--my-var); }
+  `);
+
+  render(
+    <VariableContextProvider value={{ "--my-var": "red" }}>
+      <VariableContextProvider value={{ "--my-var": undefined }}>
+        <View testID={testID} className="test" />
+      </VariableContextProvider>
+    </VariableContextProvider>,
+  );
+
+  const component = screen.getByTestId(testID);
+  expect(component.props.style).toStrictEqual({ color: "red" });
+});
+
+test("VariableContextProvider with an undefined value falls through to :root", () => {
+  registerCSS(`
+    :root { --my-var: green; }
+    .other { --my-var: blue; }
+    .test { color: var(--my-var); }
+  `);
+
+  render(
+    <VariableContextProvider value={{ "--my-var": undefined }}>
+      <View testID={testID} className="test" />
+    </VariableContextProvider>,
+  );
+
+  const component = screen.getByTestId(testID);
+  expect(component.props.style).toStrictEqual({ color: "green" });
+});
+
+test("VariableContextProvider with an undefined value leaves the var() fallback reachable", () => {
+  // Nothing sets `--my-var` on the ancestor chain, so the fallback is the only
+  // value `.test` can reach.
+  registerCSS(`
+    .other { --my-var: blue; }
+    .other-2 { --my-var: purple; }
+    .test { color: var(--my-var, green); }
+  `);
+
+  render(
+    <VariableContextProvider value={{ "--my-var": undefined }}>
+      <View testID={testID} className="test" />
+    </VariableContextProvider>,
+  );
+
+  const component = screen.getByTestId(testID);
+  expect(component.props.style).toStrictEqual({ color: "green" });
+});
+
+test("VariableContextProvider clears a variable with unset", () => {
+  registerCSS(`
+    :root { --my-var: green; }
+    .other { --my-var: blue; }
+    .test { color: var(--my-var); }
+  `);
+
+  render(
+    <VariableContextProvider value={{ "--my-var": "red" }}>
+      <VariableContextProvider value={{ "--my-var": "unset" }}>
+        <View testID={testID} className="test" />
+      </VariableContextProvider>
+    </VariableContextProvider>,
+  );
+
+  const component = screen.getByTestId(testID);
+  expect(component.props.style).toStrictEqual({ color: undefined });
 });
 
 test("variable overriding with classes", () => {

--- a/src/__tests__/native/vars.test.tsx
+++ b/src/__tests__/native/vars.test.tsx
@@ -4,6 +4,11 @@ import { View } from "react-native-css/components/View";
 import { registerCSS, testID } from "react-native-css/jest";
 import { vars } from "react-native-css/runtime";
 
+// `vars()` is platform-split and `react-native-css/runtime` is its web half to
+// TypeScript. The case below is about what the native implementation stores, so
+// it reaches that implementation directly, as units.test.tsx does.
+import { vars as nativeVars } from "../../native/api";
+
 test("vars", () => {
   registerCSS(
     `.my-class {
@@ -35,4 +40,11 @@ test("vars", () => {
   expect(element.props.style).toMatchObject({
     color: "blue",
   });
+});
+
+test("vars does not create a key for an undefined value", () => {
+  const inline = nativeVars({ "--defined": "red", "--absent": undefined });
+
+  expect(Object.keys(inline)).toStrictEqual(["defined"]);
+  expect("absent" in inline).toBe(false);
 });

--- a/src/native-internal/variables.tsx
+++ b/src/native-internal/variables.tsx
@@ -7,7 +7,11 @@ import {
 
 import type { StyleDescriptor } from "react-native-css/compiler";
 
-import { VAR_SYMBOL, type VariableContextValue } from "../native/reactivity";
+import {
+  toVariableRecord,
+  VAR_SYMBOL,
+  type VariableContextValue,
+} from "../native/reactivity";
 
 globalThis.__react_native_css_variable_context ??=
   createContext<VariableContextValue>({
@@ -24,9 +28,7 @@ export function VariableContextProvider(
   const value: VariableContextValue = useMemo(
     () => ({
       ...inheritedVariables,
-      ...Object.fromEntries(
-        Object.entries(props.value).map(([k, v]) => [k.replace(/^--/, ""), v]),
-      ),
+      ...toVariableRecord(props.value),
       [VAR_SYMBOL]: true,
     }),
     [inheritedVariables, props.value],

--- a/src/native/api.tsx
+++ b/src/native/api.tsx
@@ -16,6 +16,7 @@ import { mappingToConfig, useNativeCss } from "./react/useNativeCss";
 import { usePassthrough } from "./react/usePassthrough";
 import {
   colorScheme as colorSchemeObs,
+  toVariableRecord,
   VAR_SYMBOL,
   type Effect,
   type Getter,
@@ -115,10 +116,5 @@ export function useNativeVariable(name: string) {
  * @deprecated Use `<VariableContextProvider />` instead.
  */
 export function vars(variables: Record<string, StyleDescriptor>) {
-  return Object.assign(
-    { [VAR_SYMBOL]: "inline" },
-    Object.fromEntries(
-      Object.entries(variables).map(([k, v]) => [k.replace(/^--/, ""), v]),
-    ),
-  );
+  return Object.assign({ [VAR_SYMBOL]: "inline" }, toVariableRecord(variables));
 }

--- a/src/native/reactivity.ts
+++ b/src/native/reactivity.ts
@@ -186,6 +186,31 @@ export type VariableContextValue = Record<string, StyleDescriptor> & {
   [VAR_SYMBOL]: true;
 };
 
+/**
+ * Normalises the `Record<"--name", value>` shape the two JavaScript channels
+ * into the variable system accept - `vars()` and `<VariableContextProvider />` -
+ * into the unprefixed record the runtime stores.
+ *
+ * An entry with no value produces no key. Variable lookup is presence-keyed
+ * (`name in variables`), so a key holding `undefined` reads as "this variable
+ * is set to nothing" and stops the cascade before the inherited value, the
+ * `:root` value and the `var()` fallback. Absence is how a record spells "no
+ * value"; `"unset"` is how a variable is deliberately cleared.
+ */
+export function toVariableRecord(
+  variables: Record<string, StyleDescriptor>,
+): Record<string, StyleDescriptor> {
+  const record: Record<string, StyleDescriptor> = {};
+
+  for (const [name, value] of Object.entries(variables)) {
+    if (value !== undefined) {
+      record[name.replace(/^--/, "")] = value;
+    }
+  }
+
+  return record;
+}
+
 /** Pseudo Classes ************************************************************/
 
 export const hoverFamily = weakFamily(() => observable(false));


### PR DESCRIPTION
## The defect

`vars()` and `<VariableContextProvider />` are the two JavaScript channels into the native variable system. Both map every entry of the record they are handed into the runtime's variable record, so an entry whose value is `undefined` plants a key holding `undefined`.

Variable lookup is presence-keyed. `varResolver` returns on `name in variables` before it reaches the inline record, the `:root` record or the `var()` fallback:

```ts
// src/native/styles/variables.ts
if (name in variables) {
  renderGuards?.push(["v", name, variables[name]]);
  return resolve(variables[name]); // resolve(undefined) === undefined
}
```

So a key with no value reads as *"this variable is set to nothing"*, and the property it feeds is dropped rather than resolved. Measured on `main` (`f70c402`), with `--my-var` defined twice so the compiler cannot inline it and the value is genuinely read at runtime:

| Tree | Contract | `main` |
| --- | --- | --- |
| `<Provider value={{"--my-var": "red"}}>` › `<Provider value={{"--my-var": undefined}}>` › `.test { color: var(--my-var) }` | `{ color: "red" }` | `{}` |
| `:root { --my-var: green }`, `<Provider value={{"--my-var": undefined}}>` › `.test { color: var(--my-var) }` | `{ color: "green" }` | `{}` |
| `<Provider value={{"--my-var": undefined}}>` › `.test { color: var(--my-var, green) }` | `{ color: "green" }` | `{}` |
| `vars({ "--defined": "red", "--absent": undefined })` | one key | two keys |

A single definition of the variable hides all of this: the compiler folds it into the consuming declaration and no runtime `var()` read happens, so the property is correct for a reason unrelated to the variable record.

## Where it belongs

The compiler already holds this invariant one plane over:

```ts
// src/compiler/stylesheet.ts
if (value === undefined) {
  return;
}
...
} else if (property.startsWith("--")) {
  rule.v ??= [];
  rule.v.push([property.slice(2), value]);
}
```

No compiled rule can carry a variable entry without a value — a `--x: initial` whose value computes to nothing drops out of the emitted sheet entirely rather than being emitted as an empty entry. The two runtime channels into the same record are the ones that were missing the guard.

`assignInheritedVariables` looks like the shared choke point, and is not: it writes `target[name] = value` unconditionally and sits only on the descendant path, while a `vars()` object reaches an element's own scope through `rules.ts` → `calculate-props.ts`'s `Object.assign(inlineVariables, rule)`. Fixing it there would leave the reported case unchanged.

## The change

Both call sites built their entry list with the same expression:

```ts
Object.fromEntries(
  Object.entries(variables).map(([k, v]) => [k.replace(/^--/, ""), v]),
)
```

so this is one `toVariableRecord`, placed beside `VAR_SYMBOL` and `VariableContextValue` in `src/native/reactivity.ts` — the module both call sites already import from, so no new import edge. It strips the `--` prefix and skips an entry with no value.

Absence is how a record spells *"no value"*. `"unset"` remains how a variable is deliberately cleared, and is covered by a test so the drop cannot widen into one.

## Tests

Five cases, each confirmed red against unfixed code for the reason above and green after. Reverting each call site to its inline form independently turns only that site's cases red; making `toVariableRecord` drop every entry turns the two pre-existing `vars` / `VariableContextProvider` cases red as well.

```
Test Suites: 2 failed, 4 skipped, 53 passed, 55 of 59 total
Tests:       3 failed, 21 skipped, 1053 passed, 1077 total
```

The 3 failures are the pre-existing Windows-only `babel-plugin-tester` mismatches over an unrewritten relative `require("../View")`, identical on `main` before this change (`1048 passed, 1072 total`). `yarn typecheck` and `yarn lint` are clean.

`variables.test.tsx` and one new case in `vars.test.tsx` import through `react-native-css/native` / the native module rather than `react-native-css`, because the root `tsconfig` resolves the package specifier to the web half and the cases are about what the native implementation stores. `units.test.tsx` and `media-query.test.tsx` already reach the native surface the same way.

## Scope

Native only. #423 carries the web half of the same contract — `toCustomProperties` there drops an undefined value before it reaches a style object — and the two do not touch the same files.
