### PR TITLE
fix(native): rank an unset specificity slot the same however it is spelled

### DIFF
--- a/src/__tests__/native/specificity.test.tsx
+++ b/src/__tests__/native/specificity.test.tsx
@@ -1,9 +1,12 @@
 import { StyleSheet, type ViewProps } from "react-native";
 
 import { fireEvent, render } from "@testing-library/react-native";
+import type { StyleRule } from "react-native-css/compiler";
+import { compile } from "react-native-css/compiler";
 import { Text } from "react-native-css/components/Text";
 import { registerCSS, testID } from "react-native-css/jest";
 import { styled } from "react-native-css/runtime";
+import { specificityCompareFn } from "react-native-css/utilities/specificity";
 
 test("inline styles", () => {
   registerCSS(`.red { background-color: red; }`);
@@ -187,4 +190,46 @@ test("passThrough - inline important existing", () => {
   expect(StyleSheet.flatten(component.props.style)).toStrictEqual({
     color: "#00f",
   });
+});
+
+test("a pseudo-element rule still outranks a plain one after the sheet is serialised", () => {
+  // The compiler leaves HOLES: a rule that sets `PseudoElements` (slot 4) never
+  // writes slots 2 and 3, so they sit empty *inside* the array's length. Metro
+  // writes the sheet with `JSON.stringify` (`metro/injection-code.ts`), and JSON
+  // has no holes — every one becomes `null`.
+  //
+  // The comparator branched on the RAW slot while returning a NORMALISED
+  // difference, so `undefined !== null` entered the branch and returned
+  // `0 - 0 = 0`, settling the comparison at a slot neither rule uses. A zero
+  // leaves the runtime sort with nothing to order by, so the `className`
+  // attribute's token order decided the cascade — `placeholder:` and
+  // `selection:` are the everyday Tailwind triggers.
+  //
+  // Asserted at the comparator rather than through a render on purpose. The
+  // rendered form depends on a non-`color` declaration leaking out of the
+  // pseudo-element rule, so it would go inert the moment that leak is fixed;
+  // this assertion does not.
+  const rules = compile(
+    `.inp { color: red; } .inp::placeholder { color: blue; }`,
+  ).stylesheet().s?.[0]?.[1];
+
+  if (rules === undefined) {
+    throw new Error(
+      "compiled no rules for .inp — the fixture or the compiler moved",
+    );
+  }
+
+  // The shape a device receives, not the shape the compiler holds.
+  const [plain, placeholder] = JSON.parse(JSON.stringify(rules)) as StyleRule[];
+
+  if (plain === undefined || placeholder === undefined) {
+    throw new Error("expected two rules");
+  }
+
+  expect(specificityCompareFn(plain, placeholder)).toBeLessThan(0);
+  expect(specificityCompareFn(placeholder, plain)).toBeGreaterThan(0);
+
+  // An inline record carries no `s` at all, so it falls back to
+  // `inlineSpecificity` — itself a sparse array. It must still win.
+  expect(specificityCompareFn({}, placeholder)).toBeGreaterThan(0);
 });

--- a/src/utilities/specificity.ts
+++ b/src/utilities/specificity.ts
@@ -22,6 +22,20 @@ const Order = Specificity.Order;
 export const inlineSpecificity: SpecificityArray = [];
 inlineSpecificity[Specificity.Inline] = 1;
 
+/**
+ * What a slot is worth. An unset slot is worth nothing, however it is spelled.
+ *
+ * A specificity array is SPARSE: a rule that sets `PseudoElements` never writes
+ * `Important` or `Inline`, so those sit as holes inside the array's length. A
+ * hole reads as `undefined` in memory, and the sheet reaches a native runtime
+ * through `JSON.stringify` (`metro/injection-code.ts`), which has no holes and
+ * writes each one as `null`. Both mean "unset", so both must rank the same.
+ */
+const rank = (spec: SpecificityArray, slot: number): number => spec[slot] || 0;
+
+/** Most significant first. */
+const slots = [Important, Inline, PseudoElements, ClassName, Order];
+
 export const specificityCompareFn = (
   a: StyleRule | InlineStyleRecord,
   b: StyleRule | InlineStyleRecord,
@@ -29,17 +43,16 @@ export const specificityCompareFn = (
   const aSpec = a.s ? a.s : inlineSpecificity;
   const bSpec = b.s ? b.s : inlineSpecificity;
 
-  if (aSpec[Important] !== bSpec[Important]) {
-    return (aSpec[Important] || 0) - (bSpec[Important] || 0);
-  } else if (aSpec[Inline] !== bSpec[Inline]) {
-    return (aSpec[Inline] || 0) - (bSpec[Inline] || 0);
-  } else if (aSpec[PseudoElements] !== bSpec[PseudoElements]) {
-    return (aSpec[PseudoElements] || 0) - (bSpec[PseudoElements] || 0);
-  } else if (aSpec[ClassName] !== bSpec[ClassName]) {
-    return (aSpec[ClassName] || 0) - (bSpec[ClassName] || 0);
-  } else if (aSpec[Order] !== bSpec[Order]) {
-    return (aSpec[Order] || 0) - (bSpec[Order] || 0);
-  } else {
-    return 0;
+  // Compare the RANKED value, never the raw slot. Branching on the raw slot
+  // while returning a normalised difference is what let `undefined !== null`
+  // enter a branch and answer `0 - 0`, settling the comparison at a slot
+  // neither rule uses and leaving the caller to fall back on source order.
+  for (const slot of slots) {
+    const difference = rank(aSpec, slot) - rank(bSpec, slot);
+    if (difference !== 0) {
+      return difference;
+    }
   }
+
+  return 0;
 };


### PR DESCRIPTION
## Problem

`specificityCompareFn` can return `0` for two rules that are not equally specific, once the stylesheet has been through Metro.

A specificity array is **sparse**. A rule that sets `PseudoElements` never writes `Important` or `Inline` — `selector-builder.ts` merges with `if (value !== undefined)`, and `stylesheet.ts` skips an absent spec entirely — so those slots are holes *inside* the array's length:

```
.inp              ->  [1, 1]
.inp::placeholder ->  [2, 1, <2 empty items>, 1]
```

A hole reads as `undefined` in memory. `getNativeInjectionCode` (`src/metro/injection-code.ts`) writes the sheet with `JSON.stringify`, and JSON has no holes, so a device receives:

```
[2, 1, null, null, 1]
```

The comparator branches on the **raw** slot while returning a **normalised** difference:

```ts
if (aSpec[Important] !== bSpec[Important]) {
  return (aSpec[Important] || 0) - (bSpec[Important] || 0);
```

`undefined !== null` is true, so the comparison enters that branch and answers `0 - 0` — settling at a slot neither rule uses, and never reaching the one that decides.

## Why it is visible

The caller is the runtime sort in `src/native/styles/index.ts`, over rules gathered across every class name on the element. A `0` verdict leaves it nothing to order by, so the `className` attribute's token order decides the cascade:

```
className="inp inp-ph"   ->  one result
className="inp-ph inp"   ->  the other
```

`placeholder:` and `selection:` are the everyday Tailwind triggers, and `::selection` / `::placeholder` are the only two pseudo-elements this compiler emits.

The **compile-time** sort in `src/compiler/stylesheet.ts` runs on the in-memory form, where the holes are still holes, and is correct. That is also why the current suite does not catch this: the compile-time sort masks it whenever two rules share a class name, and only the runtime sort — over a cross-class set — is exposed.

## Fix

Compare the ranked value rather than the raw slot:

```ts
const rank = (spec: SpecificityArray, slot: number): number => spec[slot] || 0;
```

The loop is part of the fix, not cosmetic. Returning inside a raw-slot branch is what made a `0` difference **terminal** instead of falling through to the next slot; that behaviour is reproducible by restoring the early return inside the loop, and it is what the new test pins.

## Scope

This touches the comparator only. Every other `Specificity.` read is compile time (`selector-builder.ts`, `stylesheet.ts`), where the array still has its holes and is already correct — there are no `.s[` reads anywhere under `src/native`. Nothing else needs to change.

## Test

`src/__tests__/native/specificity.test.tsx` gains one case. It asserts at the comparator, over a sheet put through the same `JSON.stringify` round trip a device receives, and covers both directions plus the inline-record fallback (`inlineSpecificity` is itself a sparse array, so an inline style must still win).

Measured on this branch: **red at `Received: 0`, green after.**

A rendered test would be the more obvious choice and is deliberately not what this uses. Making the tie visible in rendered output needs a non-`color` declaration to leak out of the pseudo-element rule, so a rendered assertion would go inert as soon as that leak is fixed. The comparator assertion does not depend on it.

## Verification

- New test red before / green after, on this branch.
- Full suite: `3 failed, 21 skipped, 1049 passed, 1073 total`. The three are `src/__tests__/babel/*` path suites, unrelated to this change and pre-existing on this base — they fail identically with `src/utilities/specificity.ts` reverted.
- `yarn typecheck` and `yarn lint` both clean.
- Differential check over 5184 compiler-shaped pairs (order × classes × important × pseudo-element): **0 disagreements** against the current comparator on the in-memory form, so no existing behaviour changes; **1152 disagreements** on the post-`JSON.stringify` form — half of every pair where exactly one rule carries a pseudo-element.
