### PR TITLE
fix(native): one resolved-style cache key per distinct input set

### DIFF
--- a/src/__tests__/native/config-identity.test.ts
+++ b/src/__tests__/native/config-identity.test.ts
@@ -1,0 +1,121 @@
+import { ScrollView as RNScrollView, View as RNView } from "react-native";
+
+import { generateStateHash } from "../../native/react/rules";
+import {
+  mappingToConfig,
+  type ComponentState,
+  type Config,
+} from "../../native/react/useNativeCss";
+import {
+  VAR_SYMBOL,
+  type Effect,
+  type VariableContextValue,
+} from "../../native/reactivity";
+import type { StyledConfiguration } from "../../runtime.types";
+
+/**
+ * The resolved-style cache is keyed by `generateStateHash`, which hashes `state.configs` by object
+ * identity. Sharing therefore depends on one mapping producing one config array, rather than an
+ * equal array per consumer.
+ *
+ * The rules half of that key already holds: `StyleCollection.styles(className)` is keyed by the
+ * class string, so every element carrying the same class list references one rule set. The config
+ * half is the one input that is minted per consumer.
+ */
+
+/** A stand-in for the rule set a shared class list resolves to — any object is a valid weak key. */
+const ruleFor = (): WeakKey => ({});
+
+/** The smallest `ComponentState` `generateStateHash` reads: it only touches `configs`. */
+const stateFor = (configs: Config[]): ComponentState => {
+  const observers = new Set<Effect>();
+  const ruleEffect: Effect = { observers, run: () => undefined };
+  const inheritedVariables: VariableContextValue = { [VAR_SYMBOL]: true };
+
+  return {
+    configs,
+    inheritedContainers: {},
+    inheritedVariables,
+    ruleEffect,
+    ruleEffectGetter: (observable) => observable.get(ruleEffect),
+    styleEffect: { observers, run: () => undefined },
+  };
+};
+
+const viewMapping = {
+  className: "style",
+} satisfies StyledConfiguration<typeof RNView>;
+
+const scrollViewMapping = {
+  className: "style",
+  contentContainerClassName: "contentContainerStyle",
+} satisfies StyledConfiguration<typeof RNScrollView>;
+
+test("two consumers of one mapping share a cache key", () => {
+  const rules = [ruleFor()];
+
+  const first = generateStateHash(
+    stateFor(mappingToConfig(viewMapping)),
+    rules,
+  );
+  const second = generateStateHash(
+    stateFor(mappingToConfig(viewMapping)),
+    rules,
+  );
+
+  expect(first).toBe(second);
+});
+
+test("mappings that differ keep different cache keys", () => {
+  const rules = [ruleFor()];
+
+  const view = generateStateHash(stateFor(mappingToConfig(viewMapping)), rules);
+  const scrollView = generateStateHash(
+    stateFor(mappingToConfig(scrollViewMapping)),
+    rules,
+  );
+
+  expect(view).not.toBe(scrollView);
+});
+
+test("a state hash always carries the config, so it is never the empty string", () => {
+  // The empty string used to double as a no-keys sentinel in `generateStateHash`. With the key a
+  // join rather than a digest, an empty key list renders as the empty string too — so the sentinel
+  // and a real state would have shared one cache entry. The config is an unconditional key, which
+  // is what makes the sentinel unnecessary rather than merely unlikely.
+  const state = stateFor(mappingToConfig(viewMapping));
+
+  expect(generateStateHash(state, [])).not.toBe("");
+  expect(generateStateHash(state, [ruleFor()])).not.toBe("");
+});
+
+test("a mapping that is not an object is refused by name", () => {
+  // The derivation is cached on the mapping OBJECT. A primitive cannot be a weak-map key, so
+  // without this guard the failure surfaces as a `WeakMap` error naming nothing the caller wrote.
+  expect(() => mappingToConfig("style" as never)).toThrow(
+    /mapping must be an object/u,
+  );
+  expect(() => mappingToConfig(undefined as never)).toThrow(
+    /mapping must be an object/u,
+  );
+});
+
+test("a mapping mutated after its first use is not re-derived", () => {
+  // Documented rather than defended: `useCssElement` already froze the derivation per instance, so
+  // a mutation only ever reached NEWLY mounted elements — the same mapping meaning two things at
+  // once. Deriving once per mapping settles it on one.
+  const mapping: Record<string, string> = { className: "style" };
+  const first = mappingToConfig(mapping);
+
+  mapping.className = "contentContainerStyle";
+
+  expect(mappingToConfig(mapping)).toBe(first);
+});
+
+test("a mapping built per call still produces an equal config", () => {
+  // Every wrapper the library ships passes a module constant, but a caller may build the mapping
+  // inline. That path cannot share on identity and has to keep working unchanged.
+  expect(mappingToConfig({ className: "style" })).toEqual(
+    mappingToConfig(viewMapping),
+  );
+});

--- a/src/__tests__/native/family.test.ts
+++ b/src/__tests__/native/family.test.ts
@@ -1,0 +1,42 @@
+import { generateHash } from "../../native/react/rules";
+import { family, weakFamily } from "../../native/reactivity";
+
+/**
+ * `family` and `weakFamily` promise one factory call per key, and cached on the result being
+ * truthy. A factory that legitimately returns `0`, `""` or `false` was therefore re-run on every
+ * lookup, and its key never settled on a value.
+ *
+ * `hashKeyFamily` in `native/react/rules.ts` is such a factory: it hands out `hashKeyCount++`, so
+ * the first weak key ever hashed is assigned `0` and is the one key that never caches. Its hash
+ * changes between lookups, which splits every cache keyed on that hash.
+ */
+
+test("weakFamily calls its factory once per key when the result is falsy", () => {
+  let calls = 0;
+  const numbers = weakFamily<object, number>(() => calls++);
+  const key = {};
+
+  expect(numbers(key)).toBe(0);
+  expect(numbers(key)).toBe(0);
+  expect(calls).toBe(1);
+});
+
+test("family calls its factory once per key when the result is falsy", () => {
+  let calls = 0;
+  const numbers = family<string, number>(() => calls++);
+
+  expect(numbers("key")).toBe(0);
+  expect(numbers("key")).toBe(0);
+  expect(calls).toBe(1);
+});
+
+test("a weak key hashes to the same value on every lookup", () => {
+  // The key assigned `0` is the one the falsy-cache miss exposes, and it is whichever key this
+  // module hashes FIRST. Asserting the value rather than only the agreement is what keeps that
+  // true: a test added above this one that hashes would take the `0` and leave this passing
+  // against a key that was never at risk.
+  const key = {};
+
+  expect(generateHash([key])).toBe("0");
+  expect(generateHash([key])).toBe(generateHash([key]));
+});

--- a/src/__tests__/native/state-hash.test.ts
+++ b/src/__tests__/native/state-hash.test.ts
@@ -1,0 +1,73 @@
+import { generateHash } from "../../native/react/rules";
+
+/**
+ * `generateHash` keys the resolved-style cache. Two different sets of rules landing on one key does
+ * not cost a cache miss — `family` returns the entry it already holds and ignores the rules the
+ * second caller brought, so that element renders the first element's styles.
+ *
+ * Measured before this was injective: a `vertical-align: top` element rendered `object-fit: contain`
+ * because both rule sets hashed to `18h`.
+ */
+
+/** Distinct weak keys. Any object is a valid one. */
+const keysOf = (count: number): WeakKey[] =>
+  Array.from({ length: count }, () => ({}));
+
+test("distinct key sets never share a hash", () => {
+  const keys = keysOf(60);
+  const owner = new Map<string, string>();
+
+  for (const [leftIndex, left] of keys.entries()) {
+    for (const [offset, right] of keys.slice(leftIndex + 1).entries()) {
+      const signature = `${String(leftIndex)}+${String(leftIndex + 1 + offset)}`;
+      const hash = generateHash([left, right]);
+      const prior = owner.get(hash);
+
+      expect(prior ?? signature).toBe(signature);
+      owner.set(hash, signature);
+    }
+  }
+
+  // Vacuity guard: the loop above must actually have hashed every pair.
+  expect(owner.size).toBe((keys.length * (keys.length - 1)) / 2);
+});
+
+test("a key set hashes the same however it is ordered", () => {
+  // The rule set reaching `generateStateHash` is a Set built in render order, so order-independence
+  // is what lets two elements with the same rules share one entry at all.
+  const first: WeakKey = {};
+  const second: WeakKey = {};
+  const third: WeakKey = {};
+
+  expect(generateHash([first, second, third])).toBe(
+    generateHash([third, first, second]),
+  );
+});
+
+test("a key outside WeakKey is refused rather than erased", () => {
+  // The encoding is exact only if it encodes every member. Skipping one — which the inherited
+  // `if (!key) continue` did — makes `[a, b]` and `[a, falsy, b]` the same string, and a cache
+  // key collision hands the second caller the first caller's styles. Unreachable from typed code,
+  // so this pins the contract rather than a bug: out of domain fails, it does not vanish.
+  const key: WeakKey = {};
+
+  expect(() => generateHash([key, undefined as unknown as WeakKey])).toThrow();
+});
+
+test("hashing the same key twice answers the same value", () => {
+  // `hashKeyFamily` assigns each key a number once. A key whose number is not retained hashes
+  // differently on its second lookup, which splits its cache entry.
+  const only: WeakKey = {};
+
+  expect(generateHash([only])).toBe(generateHash([only]));
+});
+
+test("the encoding is integers, not floats or exponents", () => {
+  // The ordering runs through a `Float64Array`, so every member is a double by the time it is
+  // joined. `Number.prototype.toString` renders an integral double without a fraction, and only
+  // switches to exponential notation past 1e21 — far beyond a key counter. Pinning it here means a
+  // future change to the array type has to face the question rather than silently reshape the key.
+  const keys: WeakKey[] = [{}, {}, {}];
+
+  expect(generateHash(keys)).toMatch(/^\d+(?:,\d+)*$/u);
+});

--- a/src/__tests__/native/style-cache-bounds.test.tsx
+++ b/src/__tests__/native/style-cache-bounds.test.tsx
@@ -1,0 +1,104 @@
+import { View as RNView, type ViewProps } from "react-native";
+
+import { render, screen } from "@testing-library/react-native";
+import { copyComponentProperties } from "react-native-css/components/copyComponentProperties";
+import { View } from "react-native-css/components/View";
+import { registerCSS } from "react-native-css/jest";
+import { useCssElement } from "react-native-css/native";
+import type {
+  StyledConfiguration,
+  StyledProps,
+} from "react-native-css/runtime.types";
+
+import { mappingToConfig } from "../../native/react/useNativeCss";
+import { stylesFamily } from "../../native/styles";
+
+/**
+ * Sharing a cache entry across elements is only safe if the entry is (a) released when the last
+ * element using it unmounts, and (b) not consumed by whichever element reads it first.
+ *
+ * Both became load-bearing when the config stopped being per-instance: before that, every element
+ * held its own entry, so an entry that leaked was one element's worth and an entry that was drained
+ * was drained only for its owner.
+ */
+
+/** A module constant, exactly as every shipped wrapper declares it. */
+const tintedMapping = {
+  className: { target: "style", nativeStyleMapping: { color: "tintColor" } },
+} as unknown as StyledConfiguration<typeof RNView>;
+
+const Tinted = copyComponentProperties(
+  RNView,
+  (props: StyledProps<ViewProps, typeof tintedMapping>) =>
+    useCssElement(RNView, props, tintedMapping),
+);
+
+test("nothing writes to the config every element now shares", () => {
+  // While each element minted its own config, a write to one was private. Sharing makes
+  // "the consumers only read it" load-bearing rather than incidental — and that claim was
+  // inherited rather than measured.
+  //
+  // Checked by VALUE rather than by `Object.freeze`: a write to a frozen object throws only in
+  // strict mode, and measured here it does not throw at all — so a freeze-based version of this
+  // test passes whatever the code does, which is worse than not having it.
+  registerCSS(`.tinted { color: orange; }`);
+
+  const shared = mappingToConfig(tintedMapping);
+  const before = JSON.stringify(shared);
+
+  render(<Tinted className="tinted" testID="unmutated" />);
+
+  expect(JSON.stringify(shared)).toBe(before);
+  expect(screen.getByTestId("unmutated").props.tintColor).toBe("#ffa500");
+});
+
+test("a shared entry is not consumed by the first element that reads it", () => {
+  // `nativeStyleMapping` drains the resolved style in place. That is harmless when every element
+  // owns its entry and load-bearing once they share one.
+  registerCSS(`.tinted { color: orange; }`);
+  stylesFamily.clear();
+
+  render(
+    <>
+      <Tinted className="tinted" testID="a" />
+      <Tinted className="tinted" testID="b" />
+      <Tinted className="tinted" testID="c" />
+    </>,
+  );
+
+  const first = screen.getByTestId("a").props.tintColor;
+
+  expect(first).toBe("#ffa500");
+  expect(screen.getByTestId("b").props.tintColor).toBe(first);
+  expect(screen.getByTestId("c").props.tintColor).toBe(first);
+});
+
+test("the cache does not grow when a screen is entered and left repeatedly", () => {
+  // The OOM shape, and the one this PR changes. Entries are not released on unmount — that is a
+  // separate, pre-existing defect — so what matters is whether a second visit ADDS to them.
+  //
+  // With the config minted per instance, a remount produces new config identities, therefore new
+  // state hashes, therefore new entries, while the old ones stay. Measured on `main`: 2 entries
+  // after the first visit, 4 after the second, and so on without limit. Deriving the config once
+  // per mapping makes the second visit reuse the first visit's key, so the count is a function of
+  // what the app renders rather than of how often it has been rendered.
+  registerCSS(`.churn-a { color: red; } .churn-b { color: blue; }`);
+  stylesFamily.clear();
+
+  const sizes: number[] = [];
+
+  for (let cycle = 0; cycle < 25; cycle += 1) {
+    const tree = render(
+      <>
+        <View className="churn-a" />
+        <View className="churn-b" />
+      </>,
+    );
+    sizes.push(stylesFamily.size());
+    tree.unmount();
+  }
+
+  // Every cycle reaches the same count. A ratcheting cache fails on the second entry, not the last.
+  expect(new Set(sizes).size).toBe(1);
+  expect(sizes[0]).toBe(2);
+});

--- a/src/__tests__/native/style-cache-sharing.test.tsx
+++ b/src/__tests__/native/style-cache-sharing.test.tsx
@@ -1,0 +1,43 @@
+import { render } from "@testing-library/react-native";
+import { View } from "react-native-css/components/View";
+import { registerCSS } from "react-native-css/jest";
+
+import { stylesFamily } from "../../native/styles";
+
+/**
+ * The end-to-end statement of what the cache is for: it holds one entry per distinct set of
+ * resolved inputs, not one per mounted element. Everything else in the resolution path is an
+ * implementation detail of reaching that number.
+ */
+
+const ELEMENTS = 50;
+
+test("identical elements share one resolved-style cache entry", () => {
+  registerCSS(`.probe { color: red; width: 10px; }`);
+  stylesFamily.clear();
+
+  render(
+    <>
+      {Array.from({ length: ELEMENTS }, (_unused, index) => (
+        <View key={index} className="probe" />
+      ))}
+    </>,
+  );
+
+  expect(stylesFamily.size()).toBe(1);
+});
+
+test("elements with different class lists keep distinct entries", () => {
+  // The counter-case: sharing must follow the inputs, not collapse everything onto one entry.
+  registerCSS(`.red { color: red; } .blue { color: blue; }`);
+  stylesFamily.clear();
+
+  render(
+    <>
+      <View className="red" />
+      <View className="blue" />
+    </>,
+  );
+
+  expect(stylesFamily.size()).toBe(2);
+});

--- a/src/native/react/rules.ts
+++ b/src/native/react/rules.ts
@@ -289,48 +289,49 @@ const hashKeyFamily = weakFamily(() => hashKeyCount++);
 
 export function generateStateHash(
   state: ComponentState,
-  iterableKeys?: Iterable<WeakKey>,
-  variables?: WeakKey,
-  inlineVars?: Set<WeakKey>,
+  iterableKeys: Iterable<WeakKey>,
 ): string {
-  if (!iterableKeys) {
-    return "";
-  }
-
-  const keys = [state.configs, ...iterableKeys];
-
-  if (variables) {
-    keys.push(variables);
-  }
-
-  if (inlineVars) {
-    keys.push(...inlineVars);
-  }
-
-  return generateHash(keys);
+  // The config is always a key, so this never answers the empty string. That matters: the empty
+  // string used to double as a no-keys sentinel here, which would have given two different states
+  // one cache entry now that the key is a join rather than a digest.
+  return generateHash([state.configs, ...iterableKeys]);
 }
 
 /**
- * Quickly generate a unique hash for a set of numbers.
- * This is not a cryptographic hash, but it is fast and has a low chance of collision.
+ * Encode a set of weak keys as a cache key.
+ *
+ * This is an exact canonical encoding rather than a hash: it has no chance of collision, and it
+ * must not be folded back into one. The value keys the resolved-style cache, where two different
+ * key sets meeting on one string do not cost a cache miss — the second element renders the first
+ * element's styles.
+ *
+ * Every member is encoded. A key skipped here would be erased from the value, so two key sets
+ * differing only in the skipped member would collide — which is why `WeakKey` is load-bearing
+ * rather than decorative, and why a value outside it fails at the `WeakMap` rather than passing
+ * through.
  */
-const MOD = 9007199254740871; // Largest prime within safe integer range 2^53
-const PRIME = 31; // A smaller prime for mixing
 export function generateHash(keys: WeakKey[]): string {
-  let hash = 0;
-  let product = 1; // Used for mixing to enhance uniqueness
+  // A Float64Array rather than an array, because `.sort()` on a typed array is numeric and native.
+  // `Array.prototype.sort` needs a comparator to order numbers, and that comparator is a JS
+  // function Hermes calls O(n log n) times — measured on a physical device, it is the whole cost of
+  // ordering here. Float64 rather than Int32 because the key counter is unbounded and Int32 wraps
+  // silently at 2^31, which would turn two distinct key sets into one string.
+  const numbers = new Float64Array(keys.length);
+  let index = 0;
 
   for (const key of keys) {
-    if (!key) continue; // Skip if key is undefined
-
-    const num = hashKeyFamily(key);
-    hash = (hash ^ num) % MOD; // XOR and modular arithmetic
-    product = (product * (num + PRIME)) % MOD; // Mix with multiplication
+    numbers[index] = hashKeyFamily(key);
+    index += 1;
   }
 
-  // Combine hash and product to form the final hash
-  hash = (hash + product) % MOD;
+  // Sorted, so a set of keys encodes the same however it was iterated. The
+  // caller relies on that: the rule set is a Set built in render order.
+  //
+  // Joined rather than folded into a single number, so distinct key sets
+  // cannot land on one string. This value keys the resolved-style cache, and
+  // a collision there does not cost a cache miss — it hands one element
+  // another element's styles.
+  numbers.sort();
 
-  // Return the hash as a string
-  return hash.toString(36);
+  return numbers.join(",");
 }

--- a/src/native/react/useNativeCss.ts
+++ b/src/native/react/useNativeCss.ts
@@ -16,6 +16,7 @@ import { testGuards, type RenderGuard } from "../conditions/guards";
 import {
   cleanupEffect,
   ContainerContext,
+  weakFamily,
   type ContainerContextValue,
   type Effect,
   type Getter,
@@ -167,9 +168,23 @@ export function useNativeCss(
 }
 
 /**
- * Convert the styled() mapping to a config array
+ * Convert the styled() mapping to a config array.
+ *
+ * Derived once per mapping. `generateStateHash` keys the resolved-style cache on `state.configs`
+ * by object identity, so an equal-but-fresh array per consumer gives each of them its own cache
+ * entry, its own sorted rules and its own observable. `styled()` already avoids that by deriving
+ * at module scope; `useCssElement` derives per component instance, and every wrapper this library
+ * ships passes it a module constant.
+ *
+ * Caching on the mapping's identity means a mapping MUTATED after its first use is not re-derived.
+ * That is a narrowing of behaviour rather than a change of it: `useCssElement` already froze the
+ * derivation per instance through `useState`, so a live element never saw a mutation either — only
+ * a newly mounted one did, which made the same mapping mean two things at once. A caller that wants
+ * a different mapping passes a different object, which is what every call site here already does.
  */
-export function mappingToConfig(mapping: StyledConfiguration<any>) {
+const configForMapping = weakFamily(function (
+  mapping: StyledConfiguration<any>,
+): Config[] {
   return Object.entries(mapping).flatMap(([key, value]): Config => {
     if (value === true) {
       return {
@@ -213,4 +228,24 @@ export function mappingToConfig(mapping: StyledConfiguration<any>) {
 
     throw new Error(`styled(): Invalid mapping for ${key}: ${value}`);
   });
+});
+
+/**
+ * A mapping is a record of prop name to style target, and that is the only shape either entry point
+ * is typed to accept. Anything else is refused here, by name.
+ *
+ * The predicate is deliberately NARROWER than what the `WeakMap` behind `configForMapping` would
+ * take: a function and an unregistered symbol are both valid weak keys, and both are refused,
+ * because neither is a mapping. What the guard buys is the message — without it a primitive reaches
+ * that `WeakMap` and raises `Invalid value used as weak map key` from inside `reactivity`, naming
+ * neither `styled()` nor the argument that was wrong.
+ */
+export function mappingToConfig(mapping: StyledConfiguration<any>): Config[] {
+  if (typeof mapping !== "object" || mapping === null) {
+    throw new Error(
+      `styled(): mapping must be an object, received ${mapping === null ? "null" : typeof mapping}`,
+    );
+  }
+
+  return configForMapping(mapping);
 }

--- a/src/native/reactivity.ts
+++ b/src/native/reactivity.ts
@@ -130,7 +130,7 @@ export function family<Key, Result = Key, Args extends any = void>(
   return Object.assign(
     (key: Key, args: Args) => {
       let value = map.get(key);
-      if (!value) {
+      if (value === undefined) {
         value = fn(key, args);
         map.set(key, value);
       }
@@ -139,6 +139,9 @@ export function family<Key, Result = Key, Args extends any = void>(
     {
       delete(key: Key) {
         return map.delete(key);
+      },
+      size() {
+        return map.size;
       },
       clear() {
         return map.clear();
@@ -167,7 +170,7 @@ export function weakFamily<Key extends WeakKey, Args = undefined, Result = Key>(
   return Object.assign(
     (key: Key, args: Args) => {
       let value = map.get(key);
-      if (!value) {
+      if (value === undefined) {
         value = fn(key, args);
         map.set(key, value);
       }


### PR DESCRIPTION
Fixes #433.

## The defect

`stylesFamily` is keyed by `generateStateHash`, which hashes weak keys by **object identity** — so the cache shares exactly when equal inputs arrive as one object:

```ts
// src/native/react/rules.ts
const stylesObs = stylesFamily(generateStateHash(state, rules), rules);
const keys = [state.configs, ...iterableKeys];
```

The rules half holds: `StyleCollection.styles(className)` is keyed by the class string. Three defects break the rest.

### 1. The config is minted per instance

```ts
// api.tsx:54 — styled(): once, at module scope. Shares.
const configs = mappingToConfig(mapping);
// api.tsx:90 — useCssElement(): once per INSTANCE. Does not.
const [config] = useState(() => mappingToConfig(mapping));
```

`mappingToConfig` is pure in `mapping`, so it returns the same **value** and a different **identity** every time — and every wrapper this library ships takes the second path with a module constant. N identical elements therefore hold N entries, each a separately sorted rule array and a retained observable. `getRuleVariation`'s rule clone is keyed on the same identity, so that was per element rather than per mapping.

### 2. `family` and `weakFamily` cache on truthiness

```ts
let value = map.get(key);
if (!value) { value = fn(key, args); map.set(key, value); }
```

`hashKeyFamily` returns `hashKeyCount++`, so the first weak key hashed is assigned `0`, reads back as a miss, and never settles:

```
generateHash([key]) x3, first object hashed:   "v"  "x"  "x"
generateHash([key]) x3, any later object:      "z"  "z"  "z"
```

### 3. The key is lossy, and a collision is silent

Folding every key's number into one number and printing it base-36 is a digest. `family` returns the entry it holds and **ignores the `rules` the second caller brought**, so two rule sets meeting on one string do not cost a cache miss — the second element renders the first element's styles.

`(a ^ b) + (a + 31)(b + 31)` is a coarse lattice over consecutive integers, so collisions concentrate where the library spends its time:

| key shape | current | this PR |
| --- | --- | --- |
| 1 config + 1 rule — a bare `<View className="text-sm" />` | **31.99%** (28792/90000) | 0 |
| all pairs over keys 0..2999 | 39.26% | 0 |

End to end on `main`: `.probe-red` and `.probe-blue` both hash to `4u1`, resolve to the **same observable**, and the red element renders `{"color":"#00f"}`. Over those 90000 inputs the fold held 61208 entries — 28792 of the "saved" entries were wrongly-rendered elements.

The three interact: fixing (1) and (2) re-numbers the keys and moves which pairs collide, so a fix leaving the key lossy trades a memory win for a rendering bug.

## The fix

**Derive one config per mapping**, through this library's own `weakFamily` — already the derive-once-per-identity primitive behind `hoverFamily`, `getRuleVariation` and `hashKeyFamily`. The function body is untouched.

**Cache on presence** — `if (!value)` becomes `if (value === undefined)`. Of the twelve `family`/`weakFamily` call sites, `hashKeyFamily` is the only one whose factory can return a falsy value, so this changes behaviour at exactly the broken site.

**Key injectively** — collect the numbers into a `Float64Array`, sort it, join. The typed array is what makes the ordering native: `Array.prototype.sort` needs a comparator to order numbers and calls it O(n log n) times, and on Hermes that callback is most of what the ordering costs (see Cost). Sorting preserves the order-independence the fold had, which the caller relies on because the rule set is a `Set` built in render order; joining rather than folding makes distinct key sets distinct strings. `MOD` and `PRIME` have no remaining reader.

The loop's inherited `if (!key) continue` goes with them. A skipped key is erased from the value, so `[a, b]` and `[a, falsy, b]` encoded to one string — the same collision class, surviving inside the rewrite meant to remove it. Nothing reachable is affected: `WeakKey` admits no falsy value, and all four key sources are objects by construction. What changes is that an out-of-domain key now fails at the `WeakMap`, rather than either throwing later in `calculateProps` or silently taking the colliding entry, depending on which of the two arrived at the cache first.

`generateStateHash`'s empty-string sentinel goes with it: a join makes that value collidable with a real state. It was unreachable — `state.configs` is always a key — and the two parameters no caller passes go at the same time.

`family` gains `size()` beside its existing `delete` and `clear`, because a cache whose size cannot be read is one whose central invariant cannot be regression-tested. `family` and `stylesFamily` are not themselves exported — but `rootVariables` and `universalVariables` are `family` instances published through `./native-internal`, so they gain the method too. Additive, and consistent with the `delete` and `clear` already on them.

## What it measures

50 identical elements, this repo's jest environment:

| configuration | entries |
| --- | --- |
| `main` | **50** |
| falsy-cache fix only | 50 |
| config derived once per mapping only | 2 |
| all three | **1** |

The residual `2` is the key `hashKeyFamily` assigns `0`.

A physical Android device (Xiaomi Mi MIX 3), 150 identical radio controls, reading `stylesFamily` through a temporary log: **1785 → 270-271** (the count settles a single entry apart between runs; 1785 is stable across all of them). The iOS measurement in the issue is 2307 → 417 on an iPhone 12 Pro Max; different screens, so the ratios are not comparable, but neither is a rounding effect.

### The cache stops growing without limit

`stylesFamily` is never released on unmount — `stylesObs.cleanup` is reached only when a component's observable CHANGES. That is a pre-existing defect and this PR does not fix it.

What changes is whether a second visit ADDS to what is held. A remount used to produce fresh config identities, fresh hashes and fresh entries while the old ones stayed:

| mount cycle | 1 | 2 | 3 | … |
| --- | --- | --- | --- | --- |
| `main` | 2 | **4** | 6 | grows without limit |
| this PR | 2 | 2 | 2 | flat |

The bound moves from the number of MOUNTS — unbounded in a navigating app — to the number of distinct class lists, which is a property of the stylesheet.

### Rendered output is unchanged

Every element resolves the same declarations to the same values; what changes is how many times the library computes and retains them. The 1048 other tests in the suite, which assert rendered props extensively, are unchanged.

CPU is small and not claimed: one Instruments `--cpu` run per side over a 160-instance stress scene showed the JS thread at 2914ms → 2794ms and 2129ms → 2082ms, inside that suite's run-to-run spread.

## Is sharing one config safe?

While each element minted its own config, a write to one was private; sharing makes "the consumers only read it" load-bearing.

`Object.freeze` cannot check that here — a write to a frozen object throws only in strict mode, and in this repo's jest environment it does not throw at all, so a freeze-based test passes whatever the code does. The test compares the config's VALUE across a render instead, and is mutation-proven: injecting a write into `getStyledProps`'s config loop turns it red with the exact diff.

Three consequences:

- **An array `target` is aliased to the caller's array**, before and after. Deriving once changes how many config objects exist, never that aliasing.
- **A mutated mapping is no longer re-derived.** This narrows behaviour rather than changing it: `useState` already froze the derivation per instance, so a mutation reached only newly mounted elements — one mapping meaning two things depending on mount order.
- **A non-object mapping is refused by name.** `styled()` is reached from untyped JavaScript, where the type forbidding one is absent, and without the guard a primitive reaches the `WeakMap` and raises `Invalid value used as weak map key` from inside `reactivity` — naming neither `styled()` nor the argument. The predicate is deliberately narrower than that `WeakMap` contract: a function and an unregistered symbol are both valid weak keys, and both are refused, because neither is a mapping.

  It narrows six input kinds, which is worth your judgement rather than mine. `Object.entries` threw only for `null` and `undefined`; a number, boolean, function or symbol derived an empty config, and a string derived one config per character. None of those rendered anything usable — an empty config drops every prop, though note the type-legal `styled(C, {})` does that too and this PR does not change it. Two consequences follow: on the `styled()` path the throw lands at module evaluation rather than at render, and web's `styled` still no-ops on all six, so the platforms now disagree for input the types forbid.

## Cost

Instrumented over a 300-element render the key count is `min 5 · p50 10 · p90 15 · max 16`, so the band that matters is 5 to 16 keys.

The numbers below are **ratios between engines measured inside one run, not absolute timings**, captured on a physical Android device through a dev client whose clocks are thermally clamped. A uniform clamp scales every candidate in a run by the same factor, which is checkable rather than assumed: across two independent captures the ratios agreed to within 5.8% everywhere and 1.5% at 11 keys and above, while the absolutes they were computed from differed by more.

Warm lookups — hash plus `Map.get` — relative to the fold this replaces:

| keys | fold | `sort((a,b)=>a-b)` | `Float64Array.sort()` |
| --- | --- | --- | --- |
| 5 | 1.00 | 1.33 | 1.22 |
| 11 | 1.00 | 1.64 | **1.10** |
| 20 | 1.00 | 2.20 | 1.19 |
| 50 | 1.00 | 2.75 | 1.27 |

**The cost is the comparator, not the sort and not the string.** `Array.prototype.sort` cannot order numbers without one, and that comparator is a JS function the engine calls O(n log n) times. A typed array sorts numerically in native code with no callback at all. Isolating the ordering step on the same device, at 11 keys: `sort((a,b)=>a-b)` 7354 ns, `Float64Array.sort()` 3319 ns, no ordering at all 195 ns — so the callback is most of what the ordering costs, and removing it recovers most of that.

This is also where the engines disagree, which is worth stating because it decides the shape rather than merely the constant. On V8 the difference barely registers and an insertion sort is fastest at these sizes; on Hermes the same insertion sort loses badly by 50 keys, and the typed array wins at every size. The version above is the one that is never wrong on either.

`Float64Array` rather than `Int32Array`: `hashKeyCount` is unbounded and an int32 wraps silently at 2^31, which would map two distinct key sets onto one string — reintroducing exactly the collision this PR removes, in a form that only appears after two billion keys. Verified across 20 000 distinct key sets that the typed encoding agrees with the comparator sort on every one, stays order-independent, and collides on none.

**Order-independence buys nothing measurable on the screens I have.** Keying without the sort produced 271 distinct entries against the sorted key's 271 on a 150-control screen, and 119 against 119 on the shell alone. Those are counts, so no clock is involved. It is also not correctness — `"p-4 bg-red"` and `"bg-red p-4"` reach the same rules, so an order-dependent key costs a duplicate entry rather than wrong styles. I kept the sort because "no two class lists on these two screens were permutations of each other" is a fact about my stylesheet and not about your users'; at 1.10x it is no longer a trade worth making.
## Tests

Nineteen across five files, each written red first.

- `style-cache-sharing.test.tsx` — 50 identical elements produce one entry; different class lists keep distinct entries.
- `config-identity.test.ts` — two consumers of one mapping produce one key; differing mappings do not; a state hash is never the empty string; a non-object mapping is refused; a mutated mapping is not re-derived.
- `family.test.ts` — the factory-once-per-key contract for both families with a falsy result.
- `state-hash.test.ts` — distinct key sets never share a key; a key set encodes the same however ordered; a key outside `WeakKey` is refused rather than erased; the encoding is integers rather than floats or exponents.
- `style-cache-bounds.test.tsx` — nothing writes to the shared config; a shared entry survives being read; 25 mount cycles hold at one count.

Reverting each fix sends exactly the expected tests red:

| state | failing | entries for 50 elements | counts over 25 cycles |
| --- | --- | --- | --- |
| all three | 0 of 19 | 1 | 1 distinct |
| injective key reverted | 1 | 1 | 1 distinct |
| + config memo reverted | 4 | 50 | **25 distinct** |
| all three reverted | 7 | 50 | 25 distinct |

## Verification

`yarn typecheck` and `yarn lint` both exit 0. Full suite (`yarn test`), same runner, both sides measured together:

| | base (`f70c402`) | this branch |
| --- | --- | --- |
| passed | 1048 | **1067** |
| failed | 3 | 3 |
| skipped | 21 | 21 |

Exactly `+19`, and all nineteen pass. The 3 failures are identical on the unmodified base: they are the babel import-plugin's relative-import cases (`react-native › 7`, `react-native-web › 6`, `react-native-web › 17`), which are the Windows backslash-vs-forward-slash path defect I reported in #390 and are green on Linux and macOS. Nothing outside `src/__tests__/babel/` fails on either side.

One correction to the issue: its reproduction counts entries via `stylesFamily.keys()`, which does not exist on `main` — `family()` exposes `delete` and `clear` only. The tests above need no instrumentation.
