### PR TITLE
fix(exports): correct `./components/*` source targets for two non-tsx modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,30 @@
         "types": "./dist/typescript/commonjs/src/components/index.d.ts"
       }
     },
+    "./components/copyComponentProperties": {
+      "source": "./src/components/copyComponentProperties.ts",
+      "react-native": "./src/components/copyComponentProperties.ts",
+      "import": {
+        "types": "./dist/typescript/module/src/components/copyComponentProperties.d.ts",
+        "default": "./dist/module/components/copyComponentProperties.js"
+      },
+      "require": {
+        "types": "./dist/typescript/commonjs/src/components/copyComponentProperties.d.ts",
+        "default": "./dist/commonjs/components/copyComponentProperties.js"
+      }
+    },
+    "./components/index": {
+      "source": "./src/components/index.cts",
+      "react-native": "./src/components/index.cts",
+      "import": {
+        "types": "./dist/typescript/module/src/components/index.d.ts",
+        "default": "./dist/module/components/index.cjs"
+      },
+      "require": {
+        "types": "./dist/typescript/commonjs/src/components/index.d.ts",
+        "default": "./dist/commonjs/components/index.cjs"
+      }
+    },
     "./components/react-native-safe-area-context": {
       "source": "./src/components/react-native-safe-area-context.native.tsx",
       "react-native": "./src/components/react-native-safe-area-context.native.tsx",


### PR DESCRIPTION
Fixes the four broken targets reported in #445.

## The defect

`./components/*` declares `source` and `react-native` as `./src/components/*.tsx`, but two modules the pattern matches are not authored `.tsx`:

```
$ ls src/components/ | grep -E '^(index|copyComponentProperties)\.'
copyComponentProperties.ts
index.cts
index.ts
```

Export conditions match on **key presence**, not target existence, so there is no fallthrough to `import`/`require` — both subpaths are a hard `ERR_MODULE_NOT_FOUND` under either condition:

```
$ node --conditions=source -e "…require.resolve(…)"
[source] react-native-css/components/copyComponentProperties -> FAILED: MODULE_NOT_FOUND
[source] react-native-css/components/index                   -> FAILED: MODULE_NOT_FOUND
```

`react-native` is not dormant — Expo sets it for iOS and Android via `unstable_conditionsByPlatform`. `source` is the condition `react-native-builder-bob`'s example-app workflow runs on.

## The fix

Two exact keys. An exact key beats a pattern regardless of declaration order, mirroring the existing `./components/react-native-gesture-handler` entry.

`index` takes `.cts` rather than `.ts` because that is what the exact `./components` entry already declares — the wildcard's `.tsx` guess contradicted the map's own neighbouring entry.

## Verification

Applied against the published 3.0.7 tarball, both subpaths resolve under `source` and `react-native`, and every other entry is unchanged. I checked the whole map rather than just these two: **509 declared targets across every entry and every condition, 0 missing** after the fix.

That sweep is how the defect surfaced. It walks the real `dist/module/**` tree, expands each wildcard over it (skipping stems that have an exact key, since exact beats pattern) and asserts every declared target exists. It is generic — nothing in it is specific to my project — and it needs `dist/**`, so it belongs as a post-`prepare` check rather than an ordinary jest test. Happy to add it to this PR if you would like it; I left it out to keep this reviewable as a one-file fix.
