### PR TITLE
fix(compiler): read [class=…] from the prop the class list arrives on

### DIFF
--- a/src/__tests__/native/attributes.test.tsx
+++ b/src/__tests__/native/attributes.test.tsx
@@ -152,6 +152,14 @@ describe("[class=…] reads the prop the class list actually arrives on", () => 
     return style?.width;
   };
 
+  test("[class=val] compares against the WHOLE class list", () => {
+    // §6.1's `=` is an exact match on the attribute's value, and the value here
+    // is the entire class list — so the spec's own `span[class=example]` matches
+    // `class="example"` and not `class="test example"`, exactly as in a browser.
+    expect(matchedWidth(`[class='test example']`, "example")).toBe(10);
+    expect(matchedWidth(`[class='example']`, "example")).toBeUndefined();
+  });
+
   test("[class~=val] finds one word of the class list", () => {
     expect(matchedWidth(`[class~='example']`, "example")).toBe(10);
     expect(matchedWidth(`[class~='example']`, "other")).toBeUndefined();

--- a/src/__tests__/native/attributes.test.tsx
+++ b/src/__tests__/native/attributes.test.tsx
@@ -133,3 +133,42 @@ describe("dataSet attribute selector", () => {
     });
   });
 });
+
+describe("[class=…] reads the prop the class list actually arrives on", () => {
+  // CSS 2.1 §5.8.1's own example is `span[class=example]`. On React Native the
+  // class list is `className`, so an unmapped query reads `props.class` — which no
+  // element has — and answers false for every element. The compiler's own compound
+  // path already maps it, building `["a", "className", "*=", name]` for a second
+  // class name in the same selector.
+  const matchedWidth = (
+    selector: string,
+    className: string,
+  ): number | undefined => {
+    registerCSS(`.test${selector} { width: 10px; }`);
+    render(<Text testID={testID} className={`test ${className}`} />);
+    const style = screen.getByTestId(testID).props.style as
+      | { width?: number }
+      | undefined;
+    return style?.width;
+  };
+
+  test("[class~=val] finds one word of the class list", () => {
+    expect(matchedWidth(`[class~='example']`, "example")).toBe(10);
+    expect(matchedWidth(`[class~='example']`, "other")).toBeUndefined();
+  });
+
+  test("[class*=val] finds a substring of the class list", () => {
+    expect(matchedWidth(`[class*='xamp']`, "example")).toBe(10);
+    expect(matchedWidth(`[class*='xamp']`, "other")).toBeUndefined();
+  });
+
+  test("[class] is present whenever the element carries a class", () => {
+    expect(matchedWidth(`[class]`, "example")).toBe(10);
+  });
+
+  test("the name maps at the :is() build site too", () => {
+    // `:is()` builds its queries on a separate path, so the mapping has to reach
+    // it as well.
+    expect(matchedWidth(`:is([class~='example'])`, "example")).toBe(10);
+  });
+});

--- a/src/compiler/selector-builder.ts
+++ b/src/compiler/selector-builder.ts
@@ -254,13 +254,12 @@ function parseComponents(
       } else {
         // specificity[Specificity.ClassName] =
         //   (specificity[Specificity.ClassName] ?? 0) + 1;
-        const attributeQuery: AttributeQuery = component.name.startsWith(
-          "data-",
-        )
+        const name = attributePropName(component.name);
+        const attributeQuery: AttributeQuery = name.startsWith("data-")
           ? // [data-*] are turned into `dataSet` queries
-            ["d", toRNProperty(component.name.replace("data-", ""))]
+            ["d", toRNProperty(name.replace("data-", ""))]
           : // Everything else is turned into `attribute` queries
-            ["a", toRNProperty(component.name)];
+            ["a", toRNProperty(name)];
         if (component.operation) {
           let operator: AttrSelectorOperator | undefined;
           switch (component.operation.operator) {
@@ -460,11 +459,12 @@ function parseIsWhereComponents(
         // specificity[Specificity.ClassName] =
         //   (specificity[Specificity.ClassName] ?? 0) + 1;
       }
-      const attributeQuery: AttributeQuery = component.name.startsWith("data-")
+      const name = attributePropName(component.name);
+      const attributeQuery: AttributeQuery = name.startsWith("data-")
         ? // [data-*] are turned into `dataSet` queries
-          ["d", toRNProperty(component.name.replace("data-", ""))]
+          ["d", toRNProperty(name.replace("data-", ""))]
         : // Everything else is turned into `attribute` queries
-          ["a", toRNProperty(component.name)];
+          ["a", toRNProperty(name)];
       if (component.operation) {
         const operator = operatorMap[component.operation.operator];
         // Append the operator onto the attribute query
@@ -581,6 +581,19 @@ type CamelCase<S extends string> =
   S extends `${infer P1}-${infer P2}${infer P3}`
     ? `${Lowercase<P1>}${Uppercase<P2>}${CamelCase<P3>}`
     : Lowercase<S>;
+
+/**
+ * The prop an attribute name is read from.
+ *
+ * `class` is the one attribute whose React Native spelling differs: the class
+ * list arrives as `className`, so an unmapped `[class=…]` query reads `props.class`
+ * — a prop no element has — and answers false for every element. The compound
+ * form already knows this, building `["a", "className", "*=", name]` for a second
+ * class name in the same selector.
+ */
+function attributePropName(name: string): string {
+  return name === "class" ? "className" : name;
+}
 
 const operatorMap: Record<AttrOperation["operator"], AttrSelectorOperator> = {
   "equal": "=",


### PR DESCRIPTION
## Summary

`[class=…]`, `[class~=…]` and `[class]` match nothing, on every element. CSS 2.1 §5.8.1's own worked example is `span[class=example]`.

## Problem

An attribute query built from the name `class` reads `props.class`. React Native delivers the class list as `className`, so the prop never exists and every operator answers false:

| selector | element | native |
| --- | --- | --- |
| `.test[class~='example']` | `<Text className="test example" />` | no match |
| `.test[class*='xamp']` | same | no match |
| `.test[class]` | same | no match |

## Solution

One mapping, applied at both build sites. The compiler already knows it — a second class name in the same compound builds `["a", "className", "*=", name]` — so this routes both sites through `attributePropName` rather than adding a third spelling.

```ts
function attributePropName(name: string): string {
  return name === "class" ? "className" : name;
}
```

## Test plan

Five cases in `src/__tests__/native/attributes.test.tsx`, covering `=`, `~=`, `*=`, presence, and the `:is()` build site. The `=` case pins both directions of §6.1 exact matching — the value compared is the WHOLE class list, so `[class='test example']` matches `className="test example"` and `[class='example']` does not, which is what a browser answers for `span[class=example]`. Mutation-proved: making `attributePropName` the identity turns all five red and nothing else.

`yarn typecheck` and `yarn lint` clean; `yarn test` 1053 passed, 3 failed, 21 skipped. The three failures are two babel suites that fail identically on an untouched `main` worktree (Windows-only module-specifier rewrites) — this touches no babel file.

## Note

Independent of #447 — that one is what the operators do with a value, this is a name that never resolves. Both touch the same two build sites, so whichever lands second needs a trivial rebase. #449 is a third, same story.

